### PR TITLE
Allow options.links to inherit prototypically

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -218,8 +218,7 @@ Stringifier.prototype._formatNameAndType = function(type, literal) {
 	var openTag;
 
 	// replace the type with an HTML link if necessary
-	if (this._options.links && Object.prototype.hasOwnProperty.call(this._options.links,
-		nameString)) {
+	if (this._options.links && typeof this._options.links[nameString] === "string") {
 		cssClass = this._options.cssClass ? ' class="' + this._options.cssClass + '"' : '';
 
 		openTag = '<a href="' + this._options.links[nameString] + '"' + cssClass + '>';


### PR DESCRIPTION
With ES5 `Object.create`, it becomes possible for an object to be used as a dictionary (with the exception of `__proto__` until ES6).  It furthermore becomes possible for these to be scoped dictionaries, inheriting prototypically.  This would be particularly useful as a data structure for the relevant link for a term in a particular scope.

I propose a relaxation on the "ownership" requirement on the links option.  By testing instead for presence and string type, false positives from the `Object.prototype` are avoided for users not currently using `Object.create`.
