### PR TITLE
Implement TypeTuple

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -607,20 +607,37 @@ function peg$parse(input, options) {
 
               return sep + prop;
           },
-      peg$c97 = function(name) { return name; },
-      peg$c98 = "$",
-      peg$c99 = peg$literalExpectation("$", false),
-      peg$c100 = "_",
-      peg$c101 = peg$literalExpectation("_", false),
-      peg$c102 = "@",
-      peg$c103 = peg$literalExpectation("@", false),
-      peg$c104 = "-",
-      peg$c105 = peg$literalExpectation("-", false),
-      peg$c106 = "\u200C",
-      peg$c107 = peg$literalExpectation("\u200C", false),
-      peg$c108 = "\u200D",
-      peg$c109 = peg$literalExpectation("\u200D", false),
-      peg$c110 = function(parts) {
+      peg$c97 = function(head, tail) {
+              let elements = [head].concat(tail);
+              return {
+                  type: Types.TypeTuple,
+                  elements: elements
+              };
+          },
+      peg$c98 = function(tail) {
+              return tail.map(prop3);
+          },
+      peg$c99 = function(key, value) {
+              return {
+                  type: Types.NamedTupleMember,
+                  key: key,
+                  value: value
+              }
+          },
+      peg$c100 = function(name) { return name; },
+      peg$c101 = "$",
+      peg$c102 = peg$literalExpectation("$", false),
+      peg$c103 = "_",
+      peg$c104 = peg$literalExpectation("_", false),
+      peg$c105 = "@",
+      peg$c106 = peg$literalExpectation("@", false),
+      peg$c107 = "-",
+      peg$c108 = peg$literalExpectation("-", false),
+      peg$c109 = "\u200C",
+      peg$c110 = peg$literalExpectation("\u200C", false),
+      peg$c111 = "\u200D",
+      peg$c112 = peg$literalExpectation("\u200D", false),
+      peg$c113 = function(parts) {
               if (!options.jsdoc) {
                   return null;
               }
@@ -630,7 +647,7 @@ function peg$parse(input, options) {
               return `(${parts.join(', ')})`;
 
           },
-      peg$c111 = function(params) {
+      peg$c114 = function(params) {
               if (!options.jsdoc) {
                   return null;
               }
@@ -639,206 +656,206 @@ function peg$parse(input, options) {
 
               return `(${params.join(', ')})`;
           },
-      peg$c112 = "break",
-      peg$c113 = peg$literalExpectation("break", false),
-      peg$c114 = "case",
-      peg$c115 = peg$literalExpectation("case", false),
-      peg$c116 = "catch",
-      peg$c117 = peg$literalExpectation("catch", false),
-      peg$c118 = "continue",
-      peg$c119 = peg$literalExpectation("continue", false),
-      peg$c120 = "debugger",
-      peg$c121 = peg$literalExpectation("debugger", false),
-      peg$c122 = "default",
-      peg$c123 = peg$literalExpectation("default", false),
-      peg$c124 = "delete",
-      peg$c125 = peg$literalExpectation("delete", false),
-      peg$c126 = "do",
-      peg$c127 = peg$literalExpectation("do", false),
-      peg$c128 = "else",
-      peg$c129 = peg$literalExpectation("else", false),
-      peg$c130 = "finally",
-      peg$c131 = peg$literalExpectation("finally", false),
-      peg$c132 = "for",
-      peg$c133 = peg$literalExpectation("for", false),
-      peg$c134 = "if",
-      peg$c135 = peg$literalExpectation("if", false),
-      peg$c136 = "in",
-      peg$c137 = peg$literalExpectation("in", false),
-      peg$c138 = "instanceof",
-      peg$c139 = peg$literalExpectation("instanceof", false),
-      peg$c140 = "return",
-      peg$c141 = peg$literalExpectation("return", false),
-      peg$c142 = "switch",
-      peg$c143 = peg$literalExpectation("switch", false),
-      peg$c144 = "throw",
-      peg$c145 = peg$literalExpectation("throw", false),
-      peg$c146 = "try",
-      peg$c147 = peg$literalExpectation("try", false),
-      peg$c148 = "typeof",
-      peg$c149 = peg$literalExpectation("typeof", false),
-      peg$c150 = "var",
-      peg$c151 = peg$literalExpectation("var", false),
-      peg$c152 = "void",
-      peg$c153 = peg$literalExpectation("void", false),
-      peg$c154 = "while",
-      peg$c155 = peg$literalExpectation("while", false),
-      peg$c156 = "with",
-      peg$c157 = peg$literalExpectation("with", false),
-      peg$c158 = function(kw) {
+      peg$c115 = "break",
+      peg$c116 = peg$literalExpectation("break", false),
+      peg$c117 = "case",
+      peg$c118 = peg$literalExpectation("case", false),
+      peg$c119 = "catch",
+      peg$c120 = peg$literalExpectation("catch", false),
+      peg$c121 = "continue",
+      peg$c122 = peg$literalExpectation("continue", false),
+      peg$c123 = "debugger",
+      peg$c124 = peg$literalExpectation("debugger", false),
+      peg$c125 = "default",
+      peg$c126 = peg$literalExpectation("default", false),
+      peg$c127 = "delete",
+      peg$c128 = peg$literalExpectation("delete", false),
+      peg$c129 = "do",
+      peg$c130 = peg$literalExpectation("do", false),
+      peg$c131 = "else",
+      peg$c132 = peg$literalExpectation("else", false),
+      peg$c133 = "finally",
+      peg$c134 = peg$literalExpectation("finally", false),
+      peg$c135 = "for",
+      peg$c136 = peg$literalExpectation("for", false),
+      peg$c137 = "if",
+      peg$c138 = peg$literalExpectation("if", false),
+      peg$c139 = "in",
+      peg$c140 = peg$literalExpectation("in", false),
+      peg$c141 = "instanceof",
+      peg$c142 = peg$literalExpectation("instanceof", false),
+      peg$c143 = "return",
+      peg$c144 = peg$literalExpectation("return", false),
+      peg$c145 = "switch",
+      peg$c146 = peg$literalExpectation("switch", false),
+      peg$c147 = "throw",
+      peg$c148 = peg$literalExpectation("throw", false),
+      peg$c149 = "try",
+      peg$c150 = peg$literalExpectation("try", false),
+      peg$c151 = "typeof",
+      peg$c152 = peg$literalExpectation("typeof", false),
+      peg$c153 = "var",
+      peg$c154 = peg$literalExpectation("var", false),
+      peg$c155 = "void",
+      peg$c156 = peg$literalExpectation("void", false),
+      peg$c157 = "while",
+      peg$c158 = peg$literalExpectation("while", false),
+      peg$c159 = "with",
+      peg$c160 = peg$literalExpectation("with", false),
+      peg$c161 = function(kw) {
               return kw;
           },
-      peg$c159 = "class",
-      peg$c160 = peg$literalExpectation("class", false),
-      peg$c161 = "const",
-      peg$c162 = peg$literalExpectation("const", false),
-      peg$c163 = "enum",
-      peg$c164 = peg$literalExpectation("enum", false),
-      peg$c165 = "export",
-      peg$c166 = peg$literalExpectation("export", false),
-      peg$c167 = "extends",
-      peg$c168 = peg$literalExpectation("extends", false),
-      peg$c169 = "import",
-      peg$c170 = peg$literalExpectation("import", false),
-      peg$c171 = "super",
-      peg$c172 = peg$literalExpectation("super", false),
-      peg$c173 = "implements",
-      peg$c174 = peg$literalExpectation("implements", false),
-      peg$c175 = "interface",
-      peg$c176 = peg$literalExpectation("interface", false),
-      peg$c177 = "let",
-      peg$c178 = peg$literalExpectation("let", false),
-      peg$c179 = "package",
-      peg$c180 = peg$literalExpectation("package", false),
-      peg$c181 = "private",
-      peg$c182 = peg$literalExpectation("private", false),
-      peg$c183 = "protected",
-      peg$c184 = peg$literalExpectation("protected", false),
-      peg$c185 = "public",
-      peg$c186 = peg$literalExpectation("public", false),
-      peg$c187 = "static",
-      peg$c188 = peg$literalExpectation("static", false),
-      peg$c189 = "yield",
-      peg$c190 = peg$literalExpectation("yield", false),
-      peg$c191 = function(frw) {
+      peg$c162 = "class",
+      peg$c163 = peg$literalExpectation("class", false),
+      peg$c164 = "const",
+      peg$c165 = peg$literalExpectation("const", false),
+      peg$c166 = "enum",
+      peg$c167 = peg$literalExpectation("enum", false),
+      peg$c168 = "export",
+      peg$c169 = peg$literalExpectation("export", false),
+      peg$c170 = "extends",
+      peg$c171 = peg$literalExpectation("extends", false),
+      peg$c172 = "import",
+      peg$c173 = peg$literalExpectation("import", false),
+      peg$c174 = "super",
+      peg$c175 = peg$literalExpectation("super", false),
+      peg$c176 = "implements",
+      peg$c177 = peg$literalExpectation("implements", false),
+      peg$c178 = "interface",
+      peg$c179 = peg$literalExpectation("interface", false),
+      peg$c180 = "let",
+      peg$c181 = peg$literalExpectation("let", false),
+      peg$c182 = "package",
+      peg$c183 = peg$literalExpectation("package", false),
+      peg$c184 = "private",
+      peg$c185 = peg$literalExpectation("private", false),
+      peg$c186 = "protected",
+      peg$c187 = peg$literalExpectation("protected", false),
+      peg$c188 = "public",
+      peg$c189 = peg$literalExpectation("public", false),
+      peg$c190 = "static",
+      peg$c191 = peg$literalExpectation("static", false),
+      peg$c192 = "yield",
+      peg$c193 = peg$literalExpectation("yield", false),
+      peg$c194 = function(frw) {
               return frw;
           },
-      peg$c192 = "\"",
-      peg$c193 = peg$literalExpectation("\"", false),
-      peg$c194 = function(str) {
+      peg$c195 = "\"",
+      peg$c196 = peg$literalExpectation("\"", false),
+      peg$c197 = function(str) {
               return str;
           },
-      peg$c195 = "'",
-      peg$c196 = peg$literalExpectation("'", false),
-      peg$c197 = function(lit, digits, exp) {
+      peg$c198 = "'",
+      peg$c199 = peg$literalExpectation("'", false),
+      peg$c200 = function(lit, digits, exp) {
               return parseFloat(lit + '.' + (digits || '') + (exp || ''));
           },
-      peg$c198 = function(digits, exp) {
+      peg$c201 = function(digits, exp) {
               return parseFloat('.' + digits + (exp || ''));
           },
-      peg$c199 = function(lit, exp) {
+      peg$c202 = function(lit, exp) {
               return parseFloat(lit + (exp || ''));
           },
-      peg$c200 = "0",
-      peg$c201 = peg$literalExpectation("0", false),
-      peg$c202 = /^[eE]/,
-      peg$c203 = peg$classExpectation(["e", "E"], false, false),
-      peg$c204 = /^[+\-]/,
-      peg$c205 = peg$classExpectation(["+", "-"], false, false),
-      peg$c206 = /^[xX]/,
-      peg$c207 = peg$classExpectation(["x", "X"], false, false),
-      peg$c208 = function(hex) {
+      peg$c203 = "0",
+      peg$c204 = peg$literalExpectation("0", false),
+      peg$c205 = /^[eE]/,
+      peg$c206 = peg$classExpectation(["e", "E"], false, false),
+      peg$c207 = /^[+\-]/,
+      peg$c208 = peg$classExpectation(["+", "-"], false, false),
+      peg$c209 = /^[xX]/,
+      peg$c210 = peg$classExpectation(["x", "X"], false, false),
+      peg$c211 = function(hex) {
               return parseInt('0x' + hex, 16);
           },
-      peg$c209 = "null",
-      peg$c210 = peg$literalExpectation("null", false),
-      peg$c211 = "undefined",
-      peg$c212 = peg$literalExpectation("undefined", false),
-      peg$c213 = function() {
+      peg$c212 = "null",
+      peg$c213 = peg$literalExpectation("null", false),
+      peg$c214 = "undefined",
+      peg$c215 = peg$literalExpectation("undefined", false),
+      peg$c216 = function() {
               return {
                   type: Types.UnknownLiteral
               };
           },
-      peg$c214 = "true",
-      peg$c215 = peg$literalExpectation("true", false),
-      peg$c216 = "false",
-      peg$c217 = peg$literalExpectation("false", false),
-      peg$c218 = "Function",
-      peg$c219 = peg$literalExpectation("Function", false),
-      peg$c220 = "function",
-      peg$c221 = peg$literalExpectation("function", false),
-      peg$c222 = "\\",
-      peg$c223 = peg$literalExpectation("\\", false),
-      peg$c224 = "u",
-      peg$c225 = peg$literalExpectation("u", false),
-      peg$c226 = function(hex) {
+      peg$c217 = "true",
+      peg$c218 = peg$literalExpectation("true", false),
+      peg$c219 = "false",
+      peg$c220 = peg$literalExpectation("false", false),
+      peg$c221 = "Function",
+      peg$c222 = peg$literalExpectation("Function", false),
+      peg$c223 = "function",
+      peg$c224 = peg$literalExpectation("function", false),
+      peg$c225 = "\\",
+      peg$c226 = peg$literalExpectation("\\", false),
+      peg$c227 = "u",
+      peg$c228 = peg$literalExpectation("u", false),
+      peg$c229 = function(hex) {
               return String.fromCharCode(parseInt('0x' + hex), 16);
           },
-      peg$c227 = /^[0-9]/,
-      peg$c228 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c229 = /^[1-9]/,
-      peg$c230 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c231 = /^[0-9a-fA-F]/,
-      peg$c232 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c233 = peg$otherExpectation("Unicode combining mark"),
-      peg$c234 = /^[\u0903\u093E\u093F\u0940\u0949\u094A\u094B\u094C\u0982\u0983\u09BE\u09BF\u09C0\u09C7\u09C8\u09CB\u09CC\u09D7\u0A03\u0A3E\u0A3F\u0A40\u0A83\u0ABE\u0ABF\u0AC0\u0AC9\u0ACB\u0ACC\u0B02\u0B03\u0B3E\u0B40\u0B47\u0B48\u0B4B\u0B4C\u0B57\u0BBE\u0BBF\u0BC1\u0BC2\u0BC6\u0BC7\u0BC8\u0BCA\u0BCB\u0BCC\u0BD7\u0C01\u0C02\u0C03\u0C41\u0C42\u0C43\u0C44\u0C82\u0C83\u0CBE\u0CC0\u0CC1\u0CC2\u0CC3\u0CC4\u0CC7\u0CC8\u0CCA\u0CCB\u0CD5\u0CD6\u0D02\u0D03\u0D3E\u0D3F\u0D40\u0D46\u0D47\u0D48\u0D4A\u0D4B\u0D4C\u0D57\u0D82\u0D83\u0DCF\u0DD0\u0DD1\u0DD8\u0DD9\u0DDA\u0DDB\u0DDC\u0DDD\u0DDE\u0DDF\u0DF2\u0DF3\u0F3E\u0F3F\u0F7F\u102B\u102C\u1031\u1038\u103B\u103C\u1056\u1057\u1062\u1063\u1064\u1067\u1068\u1069\u106A\u106B\u106C\u106D\u1083\u1084\u1087\u1088\u1089\u108A\u108B\u108C\u108F\u17B6\u17BE\u17BF\u17C0\u17C1\u17C2\u17C3\u17C4\u17C5\u17C7\u17C8\u1923\u1924\u1925\u1926\u1929\u192A\u192B\u1930\u1931\u1933\u1934\u1935\u1936\u1937\u1938\u19B0\u19B1\u19B2\u19B3\u19B4\u19B5\u19B6\u19B7\u19B8\u19B9\u19BA\u19BB\u19BC\u19BD\u19BE\u19BF\u19C0\u19C8\u19C9\u1A19\u1A1A\u1A1B\u1B04\u1B35\u1B3B\u1B3D\u1B3E\u1B3F\u1B40\u1B41\u1B43\u1B44\u1B82\u1BA1\u1BA6\u1BA7\u1BAA\u1C24\u1C25\u1C26\u1C27\u1C28\u1C29\u1C2A\u1C2B\u1C34\u1C35\uA823\uA824\uA827\uA880\uA881\uA8B4\uA8B5\uA8B6\uA8B7\uA8B8\uA8B9\uA8BA\uA8BB\uA8BC\uA8BD\uA8BE\uA8BF\uA8C0\uA8C1\uA8C2\uA8C3\uA952\uA953\uAA2F\uAA30\uAA33\uAA34\uAA4D]/,
-      peg$c235 = peg$classExpectation(["\u0903", "\u093E", "\u093F", "\u0940", "\u0949", "\u094A", "\u094B", "\u094C", "\u0982", "\u0983", "\u09BE", "\u09BF", "\u09C0", "\u09C7", "\u09C8", "\u09CB", "\u09CC", "\u09D7", "\u0A03", "\u0A3E", "\u0A3F", "\u0A40", "\u0A83", "\u0ABE", "\u0ABF", "\u0AC0", "\u0AC9", "\u0ACB", "\u0ACC", "\u0B02", "\u0B03", "\u0B3E", "\u0B40", "\u0B47", "\u0B48", "\u0B4B", "\u0B4C", "\u0B57", "\u0BBE", "\u0BBF", "\u0BC1", "\u0BC2", "\u0BC6", "\u0BC7", "\u0BC8", "\u0BCA", "\u0BCB", "\u0BCC", "\u0BD7", "\u0C01", "\u0C02", "\u0C03", "\u0C41", "\u0C42", "\u0C43", "\u0C44", "\u0C82", "\u0C83", "\u0CBE", "\u0CC0", "\u0CC1", "\u0CC2", "\u0CC3", "\u0CC4", "\u0CC7", "\u0CC8", "\u0CCA", "\u0CCB", "\u0CD5", "\u0CD6", "\u0D02", "\u0D03", "\u0D3E", "\u0D3F", "\u0D40", "\u0D46", "\u0D47", "\u0D48", "\u0D4A", "\u0D4B", "\u0D4C", "\u0D57", "\u0D82", "\u0D83", "\u0DCF", "\u0DD0", "\u0DD1", "\u0DD8", "\u0DD9", "\u0DDA", "\u0DDB", "\u0DDC", "\u0DDD", "\u0DDE", "\u0DDF", "\u0DF2", "\u0DF3", "\u0F3E", "\u0F3F", "\u0F7F", "\u102B", "\u102C", "\u1031", "\u1038", "\u103B", "\u103C", "\u1056", "\u1057", "\u1062", "\u1063", "\u1064", "\u1067", "\u1068", "\u1069", "\u106A", "\u106B", "\u106C", "\u106D", "\u1083", "\u1084", "\u1087", "\u1088", "\u1089", "\u108A", "\u108B", "\u108C", "\u108F", "\u17B6", "\u17BE", "\u17BF", "\u17C0", "\u17C1", "\u17C2", "\u17C3", "\u17C4", "\u17C5", "\u17C7", "\u17C8", "\u1923", "\u1924", "\u1925", "\u1926", "\u1929", "\u192A", "\u192B", "\u1930", "\u1931", "\u1933", "\u1934", "\u1935", "\u1936", "\u1937", "\u1938", "\u19B0", "\u19B1", "\u19B2", "\u19B3", "\u19B4", "\u19B5", "\u19B6", "\u19B7", "\u19B8", "\u19B9", "\u19BA", "\u19BB", "\u19BC", "\u19BD", "\u19BE", "\u19BF", "\u19C0", "\u19C8", "\u19C9", "\u1A19", "\u1A1A", "\u1A1B", "\u1B04", "\u1B35", "\u1B3B", "\u1B3D", "\u1B3E", "\u1B3F", "\u1B40", "\u1B41", "\u1B43", "\u1B44", "\u1B82", "\u1BA1", "\u1BA6", "\u1BA7", "\u1BAA", "\u1C24", "\u1C25", "\u1C26", "\u1C27", "\u1C28", "\u1C29", "\u1C2A", "\u1C2B", "\u1C34", "\u1C35", "\uA823", "\uA824", "\uA827", "\uA880", "\uA881", "\uA8B4", "\uA8B5", "\uA8B6", "\uA8B7", "\uA8B8", "\uA8B9", "\uA8BA", "\uA8BB", "\uA8BC", "\uA8BD", "\uA8BE", "\uA8BF", "\uA8C0", "\uA8C1", "\uA8C2", "\uA8C3", "\uA952", "\uA953", "\uAA2F", "\uAA30", "\uAA33", "\uAA34", "\uAA4D"], false, false),
-      peg$c236 = peg$otherExpectation("Unicode decimal number"),
-      peg$c237 = /^[0123456789\u0660\u0661\u0662\u0663\u0664\u0665\u0666\u0667\u0668\u0669\u06F0\u06F1\u06F2\u06F3\u06F4\u06F5\u06F6\u06F7\u06F8\u06F9\u07C0\u07C1\u07C2\u07C3\u07C4\u07C5\u07C6\u07C7\u07C8\u07C9\u0966\u0967\u0968\u0969\u096A\u096B\u096C\u096D\u096E\u096F\u09E6\u09E7\u09E8\u09E9\u09EA\u09EB\u09EC\u09ED\u09EE\u09EF\u0A66\u0A67\u0A68\u0A69\u0A6A\u0A6B\u0A6C\u0A6D\u0A6E\u0A6F\u0AE6\u0AE7\u0AE8\u0AE9\u0AEA\u0AEB\u0AEC\u0AED\u0AEE\u0AEF\u0B66\u0B67\u0B68\u0B69\u0B6A\u0B6B\u0B6C\u0B6D\u0B6E\u0B6F\u0BE6\u0BE7\u0BE8\u0BE9\u0BEA\u0BEB\u0BEC\u0BED\u0BEE\u0BEF\u0C66\u0C67\u0C68\u0C69\u0C6A\u0C6B\u0C6C\u0C6D\u0C6E\u0C6F\u0CE6\u0CE7\u0CE8\u0CE9\u0CEA\u0CEB\u0CEC\u0CED\u0CEE\u0CEF\u0D66\u0D67\u0D68\u0D69\u0D6A\u0D6B\u0D6C\u0D6D\u0D6E\u0D6F\u0E50\u0E51\u0E52\u0E53\u0E54\u0E55\u0E56\u0E57\u0E58\u0E59\u0ED0\u0ED1\u0ED2\u0ED3\u0ED4\u0ED5\u0ED6\u0ED7\u0ED8\u0ED9\u0F20\u0F21\u0F22\u0F23\u0F24\u0F25\u0F26\u0F27\u0F28\u0F29\u1040\u1041\u1042\u1043\u1044\u1045\u1046\u1047\u1048\u1049\u1090\u1091\u1092\u1093\u1094\u1095\u1096\u1097\u1098\u1099\u17E0\u17E1\u17E2\u17E3\u17E4\u17E5\u17E6\u17E7\u17E8\u17E9\u1810\u1811\u1812\u1813\u1814\u1815\u1816\u1817\u1818\u1819\u1946\u1947\u1948\u1949\u194A\u194B\u194C\u194D\u194E\u194F\u19D0\u19D1\u19D2\u19D3\u19D4\u19D5\u19D6\u19D7\u19D8\u19D9\u1B50\u1B51\u1B52\u1B53\u1B54\u1B55\u1B56\u1B57\u1B58\u1B59\u1BB0\u1BB1\u1BB2\u1BB3\u1BB4\u1BB5\u1BB6\u1BB7\u1BB8\u1BB9\u1C40\u1C41\u1C42\u1C43\u1C44\u1C45\u1C46\u1C47\u1C48\u1C49\u1C50\u1C51\u1C52\u1C53\u1C54\u1C55\u1C56\u1C57\u1C58\u1C59\uA620\uA621\uA622\uA623\uA624\uA625\uA626\uA627\uA628\uA629\uA8D0\uA8D1\uA8D2\uA8D3\uA8D4\uA8D5\uA8D6\uA8D7\uA8D8\uA8D9\uA900\uA901\uA902\uA903\uA904\uA905\uA906\uA907\uA908\uA909\uAA50\uAA51\uAA52\uAA53\uAA54\uAA55\uAA56\uAA57\uAA58\uAA59\uFF10\uFF11\uFF12\uFF13\uFF14\uFF15\uFF16\uFF17\uFF18\uFF19]/,
-      peg$c238 = peg$classExpectation(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669", "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9", "\u07C0", "\u07C1", "\u07C2", "\u07C3", "\u07C4", "\u07C5", "\u07C6", "\u07C7", "\u07C8", "\u07C9", "\u0966", "\u0967", "\u0968", "\u0969", "\u096A", "\u096B", "\u096C", "\u096D", "\u096E", "\u096F", "\u09E6", "\u09E7", "\u09E8", "\u09E9", "\u09EA", "\u09EB", "\u09EC", "\u09ED", "\u09EE", "\u09EF", "\u0A66", "\u0A67", "\u0A68", "\u0A69", "\u0A6A", "\u0A6B", "\u0A6C", "\u0A6D", "\u0A6E", "\u0A6F", "\u0AE6", "\u0AE7", "\u0AE8", "\u0AE9", "\u0AEA", "\u0AEB", "\u0AEC", "\u0AED", "\u0AEE", "\u0AEF", "\u0B66", "\u0B67", "\u0B68", "\u0B69", "\u0B6A", "\u0B6B", "\u0B6C", "\u0B6D", "\u0B6E", "\u0B6F", "\u0BE6", "\u0BE7", "\u0BE8", "\u0BE9", "\u0BEA", "\u0BEB", "\u0BEC", "\u0BED", "\u0BEE", "\u0BEF", "\u0C66", "\u0C67", "\u0C68", "\u0C69", "\u0C6A", "\u0C6B", "\u0C6C", "\u0C6D", "\u0C6E", "\u0C6F", "\u0CE6", "\u0CE7", "\u0CE8", "\u0CE9", "\u0CEA", "\u0CEB", "\u0CEC", "\u0CED", "\u0CEE", "\u0CEF", "\u0D66", "\u0D67", "\u0D68", "\u0D69", "\u0D6A", "\u0D6B", "\u0D6C", "\u0D6D", "\u0D6E", "\u0D6F", "\u0E50", "\u0E51", "\u0E52", "\u0E53", "\u0E54", "\u0E55", "\u0E56", "\u0E57", "\u0E58", "\u0E59", "\u0ED0", "\u0ED1", "\u0ED2", "\u0ED3", "\u0ED4", "\u0ED5", "\u0ED6", "\u0ED7", "\u0ED8", "\u0ED9", "\u0F20", "\u0F21", "\u0F22", "\u0F23", "\u0F24", "\u0F25", "\u0F26", "\u0F27", "\u0F28", "\u0F29", "\u1040", "\u1041", "\u1042", "\u1043", "\u1044", "\u1045", "\u1046", "\u1047", "\u1048", "\u1049", "\u1090", "\u1091", "\u1092", "\u1093", "\u1094", "\u1095", "\u1096", "\u1097", "\u1098", "\u1099", "\u17E0", "\u17E1", "\u17E2", "\u17E3", "\u17E4", "\u17E5", "\u17E6", "\u17E7", "\u17E8", "\u17E9", "\u1810", "\u1811", "\u1812", "\u1813", "\u1814", "\u1815", "\u1816", "\u1817", "\u1818", "\u1819", "\u1946", "\u1947", "\u1948", "\u1949", "\u194A", "\u194B", "\u194C", "\u194D", "\u194E", "\u194F", "\u19D0", "\u19D1", "\u19D2", "\u19D3", "\u19D4", "\u19D5", "\u19D6", "\u19D7", "\u19D8", "\u19D9", "\u1B50", "\u1B51", "\u1B52", "\u1B53", "\u1B54", "\u1B55", "\u1B56", "\u1B57", "\u1B58", "\u1B59", "\u1BB0", "\u1BB1", "\u1BB2", "\u1BB3", "\u1BB4", "\u1BB5", "\u1BB6", "\u1BB7", "\u1BB8", "\u1BB9", "\u1C40", "\u1C41", "\u1C42", "\u1C43", "\u1C44", "\u1C45", "\u1C46", "\u1C47", "\u1C48", "\u1C49", "\u1C50", "\u1C51", "\u1C52", "\u1C53", "\u1C54", "\u1C55", "\u1C56", "\u1C57", "\u1C58", "\u1C59", "\uA620", "\uA621", "\uA622", "\uA623", "\uA624", "\uA625", "\uA626", "\uA627", "\uA628", "\uA629", "\uA8D0", "\uA8D1", "\uA8D2", "\uA8D3", "\uA8D4", "\uA8D5", "\uA8D6", "\uA8D7", "\uA8D8", "\uA8D9", "\uA900", "\uA901", "\uA902", "\uA903", "\uA904", "\uA905", "\uA906", "\uA907", "\uA908", "\uA909", "\uAA50", "\uAA51", "\uAA52", "\uAA53", "\uAA54", "\uAA55", "\uAA56", "\uAA57", "\uAA58", "\uAA59", "\uFF10", "\uFF11", "\uFF12", "\uFF13", "\uFF14", "\uFF15", "\uFF16", "\uFF17", "\uFF18", "\uFF19"], false, false),
-      peg$c239 = peg$otherExpectation("Unicode punctuation connector"),
-      peg$c240 = /^[_\u203F\u2040\u2054\uFE33\uFE34\uFE4D\uFE4E\uFE4F\uFF3F]/,
-      peg$c241 = peg$classExpectation(["_", "\u203F", "\u2040", "\u2054", "\uFE33", "\uFE34", "\uFE4D", "\uFE4E", "\uFE4F", "\uFF3F"], false, false),
-      peg$c242 = peg$otherExpectation("Unicode uppercase letter"),
-      peg$c243 = /^[ABCDEFGHIJKLMNOPQRSTUVWXYZ\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD8\xD9\xDA\xDB\xDC\xDD\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178\u0179\u017B\u017D\u0181\u0182\u0184\u0186\u0187\u0189\u018A\u018B\u018E\u018F\u0190\u0191\u0193\u0194\u0196\u0197\u0198\u019C\u019D\u019F\u01A0\u01A2\u01A4\u01A6\u01A7\u01A9\u01AC\u01AE\u01AF\u01B1\u01B2\u01B3\u01B5\u01B7\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6\u01F7\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A\u023B\u023D\u023E\u0241\u0243\u0244\u0245\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u0386\u0388\u0389\u038A\u038C\u038E\u038F\u0391\u0392\u0393\u0394\u0395\u0396\u0397\u0398\u0399\u039A\u039B\u039C\u039D\u039E\u039F\u03A0\u03A1\u03A3\u03A4\u03A5\u03A6\u03A7\u03A8\u03A9\u03AA\u03AB\u03CF\u03D2\u03D3\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9\u03FA\u03FD\u03FE\u03FF\u0400\u0401\u0402\u0403\u0404\u0405\u0406\u0407\u0408\u0409\u040A\u040B\u040C\u040D\u040E\u040F\u0410\u0411\u0412\u0413\u0414\u0415\u0416\u0417\u0418\u0419\u041A\u041B\u041C\u041D\u041E\u041F\u0420\u0421\u0422\u0423\u0424\u0425\u0426\u0427\u0428\u0429\u042A\u042B\u042C\u042D\u042E\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0531\u0532\u0533\u0534\u0535\u0536\u0537\u0538\u0539\u053A\u053B\u053C\u053D\u053E\u053F\u0540\u0541\u0542\u0543\u0544\u0545\u0546\u0547\u0548\u0549\u054A\u054B\u054C\u054D\u054E\u054F\u0550\u0551\u0552\u0553\u0554\u0555\u0556\u10A0\u10A1\u10A2\u10A3\u10A4\u10A5\u10A6\u10A7\u10A8\u10A9\u10AA\u10AB\u10AC\u10AD\u10AE\u10AF\u10B0\u10B1\u10B2\u10B3\u10B4\u10B5\u10B6\u10B7\u10B8\u10B9\u10BA\u10BB\u10BC\u10BD\u10BE\u10BF\u10C0\u10C1\u10C2\u10C3\u10C4\u10C5\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08\u1F09\u1F0A\u1F0B\u1F0C\u1F0D\u1F0E\u1F0F\u1F18\u1F19\u1F1A\u1F1B\u1F1C\u1F1D\u1F28\u1F29\u1F2A\u1F2B\u1F2C\u1F2D\u1F2E\u1F2F\u1F38\u1F39\u1F3A\u1F3B\u1F3C\u1F3D\u1F3E\u1F3F\u1F48\u1F49\u1F4A\u1F4B\u1F4C\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68\u1F69\u1F6A\u1F6B\u1F6C\u1F6D\u1F6E\u1F6F\u1FB8\u1FB9\u1FBA\u1FBB\u1FC8\u1FC9\u1FCA\u1FCB\u1FD8\u1FD9\u1FDA\u1FDB\u1FE8\u1FE9\u1FEA\u1FEB\u1FEC\u1FF8\u1FF9\u1FFA\u1FFB\u2102\u2107\u210B\u210C\u210D\u2110\u2111\u2112\u2115\u2119\u211A\u211B\u211C\u211D\u2124\u2126\u2128\u212A\u212B\u212C\u212D\u2130\u2131\u2132\u2133\u213E\u213F\u2145\u2183\u2C00\u2C01\u2C02\u2C03\u2C04\u2C05\u2C06\u2C07\u2C08\u2C09\u2C0A\u2C0B\u2C0C\u2C0D\u2C0E\u2C0F\u2C10\u2C11\u2C12\u2C13\u2C14\u2C15\u2C16\u2C17\u2C18\u2C19\u2C1A\u2C1B\u2C1C\u2C1D\u2C1E\u2C1F\u2C20\u2C21\u2C22\u2C23\u2C24\u2C25\u2C26\u2C27\u2C28\u2C29\u2C2A\u2C2B\u2C2C\u2C2D\u2C2E\u2C60\u2C62\u2C63\u2C64\u2C67\u2C69\u2C6B\u2C6D\u2C6E\u2C6F\u2C72\u2C75\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D\uA77E\uA780\uA782\uA784\uA786\uA78B\uFF21\uFF22\uFF23\uFF24\uFF25\uFF26\uFF27\uFF28\uFF29\uFF2A\uFF2B\uFF2C\uFF2D\uFF2E\uFF2F\uFF30\uFF31\uFF32\uFF33\uFF34\uFF35\uFF36\uFF37\uFF38\uFF39\uFF3A]/,
-      peg$c244 = peg$classExpectation(["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "\xC0", "\xC1", "\xC2", "\xC3", "\xC4", "\xC5", "\xC6", "\xC7", "\xC8", "\xC9", "\xCA", "\xCB", "\xCC", "\xCD", "\xCE", "\xCF", "\xD0", "\xD1", "\xD2", "\xD3", "\xD4", "\xD5", "\xD6", "\xD8", "\xD9", "\xDA", "\xDB", "\xDC", "\xDD", "\xDE", "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", "\u0178", "\u0179", "\u017B", "\u017D", "\u0181", "\u0182", "\u0184", "\u0186", "\u0187", "\u0189", "\u018A", "\u018B", "\u018E", "\u018F", "\u0190", "\u0191", "\u0193", "\u0194", "\u0196", "\u0197", "\u0198", "\u019C", "\u019D", "\u019F", "\u01A0", "\u01A2", "\u01A4", "\u01A6", "\u01A7", "\u01A9", "\u01AC", "\u01AE", "\u01AF", "\u01B1", "\u01B2", "\u01B3", "\u01B5", "\u01B7", "\u01B8", "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", "\u01F6", "\u01F7", "\u01F8", "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", "\u023A", "\u023B", "\u023D", "\u023E", "\u0241", "\u0243", "\u0244", "\u0245", "\u0246", "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u0386", "\u0388", "\u0389", "\u038A", "\u038C", "\u038E", "\u038F", "\u0391", "\u0392", "\u0393", "\u0394", "\u0395", "\u0396", "\u0397", "\u0398", "\u0399", "\u039A", "\u039B", "\u039C", "\u039D", "\u039E", "\u039F", "\u03A0", "\u03A1", "\u03A3", "\u03A4", "\u03A5", "\u03A6", "\u03A7", "\u03A8", "\u03A9", "\u03AA", "\u03AB", "\u03CF", "\u03D2", "\u03D3", "\u03D4", "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", "\u03F9", "\u03FA", "\u03FD", "\u03FE", "\u03FF", "\u0400", "\u0401", "\u0402", "\u0403", "\u0404", "\u0405", "\u0406", "\u0407", "\u0408", "\u0409", "\u040A", "\u040B", "\u040C", "\u040D", "\u040E", "\u040F", "\u0410", "\u0411", "\u0412", "\u0413", "\u0414", "\u0415", "\u0416", "\u0417", "\u0418", "\u0419", "\u041A", "\u041B", "\u041C", "\u041D", "\u041E", "\u041F", "\u0420", "\u0421", "\u0422", "\u0423", "\u0424", "\u0425", "\u0426", "\u0427", "\u0428", "\u0429", "\u042A", "\u042B", "\u042C", "\u042D", "\u042E", "\u042F", "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", "\u04C0", "\u04C1", "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0531", "\u0532", "\u0533", "\u0534", "\u0535", "\u0536", "\u0537", "\u0538", "\u0539", "\u053A", "\u053B", "\u053C", "\u053D", "\u053E", "\u053F", "\u0540", "\u0541", "\u0542", "\u0543", "\u0544", "\u0545", "\u0546", "\u0547", "\u0548", "\u0549", "\u054A", "\u054B", "\u054C", "\u054D", "\u054E", "\u054F", "\u0550", "\u0551", "\u0552", "\u0553", "\u0554", "\u0555", "\u0556", "\u10A0", "\u10A1", "\u10A2", "\u10A3", "\u10A4", "\u10A5", "\u10A6", "\u10A7", "\u10A8", "\u10A9", "\u10AA", "\u10AB", "\u10AC", "\u10AD", "\u10AE", "\u10AF", "\u10B0", "\u10B1", "\u10B2", "\u10B3", "\u10B4", "\u10B5", "\u10B6", "\u10B7", "\u10B8", "\u10B9", "\u10BA", "\u10BB", "\u10BC", "\u10BD", "\u10BE", "\u10BF", "\u10C0", "\u10C1", "\u10C2", "\u10C3", "\u10C4", "\u10C5", "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", "\u1F08", "\u1F09", "\u1F0A", "\u1F0B", "\u1F0C", "\u1F0D", "\u1F0E", "\u1F0F", "\u1F18", "\u1F19", "\u1F1A", "\u1F1B", "\u1F1C", "\u1F1D", "\u1F28", "\u1F29", "\u1F2A", "\u1F2B", "\u1F2C", "\u1F2D", "\u1F2E", "\u1F2F", "\u1F38", "\u1F39", "\u1F3A", "\u1F3B", "\u1F3C", "\u1F3D", "\u1F3E", "\u1F3F", "\u1F48", "\u1F49", "\u1F4A", "\u1F4B", "\u1F4C", "\u1F4D", "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", "\u1F68", "\u1F69", "\u1F6A", "\u1F6B", "\u1F6C", "\u1F6D", "\u1F6E", "\u1F6F", "\u1FB8", "\u1FB9", "\u1FBA", "\u1FBB", "\u1FC8", "\u1FC9", "\u1FCA", "\u1FCB", "\u1FD8", "\u1FD9", "\u1FDA", "\u1FDB", "\u1FE8", "\u1FE9", "\u1FEA", "\u1FEB", "\u1FEC", "\u1FF8", "\u1FF9", "\u1FFA", "\u1FFB", "\u2102", "\u2107", "\u210B", "\u210C", "\u210D", "\u2110", "\u2111", "\u2112", "\u2115", "\u2119", "\u211A", "\u211B", "\u211C", "\u211D", "\u2124", "\u2126", "\u2128", "\u212A", "\u212B", "\u212C", "\u212D", "\u2130", "\u2131", "\u2132", "\u2133", "\u213E", "\u213F", "\u2145", "\u2183", "\u2C00", "\u2C01", "\u2C02", "\u2C03", "\u2C04", "\u2C05", "\u2C06", "\u2C07", "\u2C08", "\u2C09", "\u2C0A", "\u2C0B", "\u2C0C", "\u2C0D", "\u2C0E", "\u2C0F", "\u2C10", "\u2C11", "\u2C12", "\u2C13", "\u2C14", "\u2C15", "\u2C16", "\u2C17", "\u2C18", "\u2C19", "\u2C1A", "\u2C1B", "\u2C1C", "\u2C1D", "\u2C1E", "\u2C1F", "\u2C20", "\u2C21", "\u2C22", "\u2C23", "\u2C24", "\u2C25", "\u2C26", "\u2C27", "\u2C28", "\u2C29", "\u2C2A", "\u2C2B", "\u2C2C", "\u2C2D", "\u2C2E", "\u2C60", "\u2C62", "\u2C63", "\u2C64", "\u2C67", "\u2C69", "\u2C6B", "\u2C6D", "\u2C6E", "\u2C6F", "\u2C72", "\u2C75", "\u2C80", "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", "\uA77D", "\uA77E", "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uFF21", "\uFF22", "\uFF23", "\uFF24", "\uFF25", "\uFF26", "\uFF27", "\uFF28", "\uFF29", "\uFF2A", "\uFF2B", "\uFF2C", "\uFF2D", "\uFF2E", "\uFF2F", "\uFF30", "\uFF31", "\uFF32", "\uFF33", "\uFF34", "\uFF35", "\uFF36", "\uFF37", "\uFF38", "\uFF39", "\uFF3A"], false, false),
-      peg$c245 = peg$otherExpectation("Unicode lowercase letter"),
-      peg$c246 = /^[abcdefghijklmnopqrstuvwxyz\xAA\xB5\xBA\xDF\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E\u017F\u0180\u0183\u0185\u0188\u018C\u018D\u0192\u0195\u0199\u019A\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9\u01BA\u01BD\u01BE\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233\u0234\u0235\u0236\u0237\u0238\u0239\u023C\u023F\u0240\u0242\u0247\u0249\u024B\u024D\u024F\u0250\u0251\u0252\u0253\u0254\u0255\u0256\u0257\u0258\u0259\u025A\u025B\u025C\u025D\u025E\u025F\u0260\u0261\u0262\u0263\u0264\u0265\u0266\u0267\u0268\u0269\u026A\u026B\u026C\u026D\u026E\u026F\u0270\u0271\u0272\u0273\u0274\u0275\u0276\u0277\u0278\u0279\u027A\u027B\u027C\u027D\u027E\u027F\u0280\u0281\u0282\u0283\u0284\u0285\u0286\u0287\u0288\u0289\u028A\u028B\u028C\u028D\u028E\u028F\u0290\u0291\u0292\u0293\u0295\u0296\u0297\u0298\u0299\u029A\u029B\u029C\u029D\u029E\u029F\u02A0\u02A1\u02A2\u02A3\u02A4\u02A5\u02A6\u02A7\u02A8\u02A9\u02AA\u02AB\u02AC\u02AD\u02AE\u02AF\u0371\u0373\u0377\u037B\u037C\u037D\u0390\u03AC\u03AD\u03AE\u03AF\u03B0\u03B1\u03B2\u03B3\u03B4\u03B5\u03B6\u03B7\u03B8\u03B9\u03BA\u03BB\u03BC\u03BD\u03BE\u03BF\u03C0\u03C1\u03C2\u03C3\u03C4\u03C5\u03C6\u03C7\u03C8\u03C9\u03CA\u03CB\u03CC\u03CD\u03CE\u03D0\u03D1\u03D5\u03D6\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF\u03F0\u03F1\u03F2\u03F3\u03F5\u03F8\u03FB\u03FC\u0430\u0431\u0432\u0433\u0434\u0435\u0436\u0437\u0438\u0439\u043A\u043B\u043C\u043D\u043E\u043F\u0440\u0441\u0442\u0443\u0444\u0445\u0446\u0447\u0448\u0449\u044A\u044B\u044C\u044D\u044E\u044F\u0450\u0451\u0452\u0453\u0454\u0455\u0456\u0457\u0458\u0459\u045A\u045B\u045C\u045D\u045E\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0561\u0562\u0563\u0564\u0565\u0566\u0567\u0568\u0569\u056A\u056B\u056C\u056D\u056E\u056F\u0570\u0571\u0572\u0573\u0574\u0575\u0576\u0577\u0578\u0579\u057A\u057B\u057C\u057D\u057E\u057F\u0580\u0581\u0582\u0583\u0584\u0585\u0586\u0587\u1D00\u1D01\u1D02\u1D03\u1D04\u1D05\u1D06\u1D07\u1D08\u1D09\u1D0A\u1D0B\u1D0C\u1D0D\u1D0E\u1D0F\u1D10\u1D11\u1D12\u1D13\u1D14\u1D15\u1D16\u1D17\u1D18\u1D19\u1D1A\u1D1B\u1D1C\u1D1D\u1D1E\u1D1F\u1D20\u1D21\u1D22\u1D23\u1D24\u1D25\u1D26\u1D27\u1D28\u1D29\u1D2A\u1D2B\u1D62\u1D63\u1D64\u1D65\u1D66\u1D67\u1D68\u1D69\u1D6A\u1D6B\u1D6C\u1D6D\u1D6E\u1D6F\u1D70\u1D71\u1D72\u1D73\u1D74\u1D75\u1D76\u1D77\u1D79\u1D7A\u1D7B\u1D7C\u1D7D\u1D7E\u1D7F\u1D80\u1D81\u1D82\u1D83\u1D84\u1D85\u1D86\u1D87\u1D88\u1D89\u1D8A\u1D8B\u1D8C\u1D8D\u1D8E\u1D8F\u1D90\u1D91\u1D92\u1D93\u1D94\u1D95\u1D96\u1D97\u1D98\u1D99\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95\u1E96\u1E97\u1E98\u1E99\u1E9A\u1E9B\u1E9C\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF\u1F00\u1F01\u1F02\u1F03\u1F04\u1F05\u1F06\u1F07\u1F10\u1F11\u1F12\u1F13\u1F14\u1F15\u1F20\u1F21\u1F22\u1F23\u1F24\u1F25\u1F26\u1F27\u1F30\u1F31\u1F32\u1F33\u1F34\u1F35\u1F36\u1F37\u1F40\u1F41\u1F42\u1F43\u1F44\u1F45\u1F50\u1F51\u1F52\u1F53\u1F54\u1F55\u1F56\u1F57\u1F60\u1F61\u1F62\u1F63\u1F64\u1F65\u1F66\u1F67\u1F70\u1F71\u1F72\u1F73\u1F74\u1F75\u1F76\u1F77\u1F78\u1F79\u1F7A\u1F7B\u1F7C\u1F7D\u1F80\u1F81\u1F82\u1F83\u1F84\u1F85\u1F86\u1F87\u1F90\u1F91\u1F92\u1F93\u1F94\u1F95\u1F96\u1F97\u1FA0\u1FA1\u1FA2\u1FA3\u1FA4\u1FA5\u1FA6\u1FA7\u1FB0\u1FB1\u1FB2\u1FB3\u1FB4\u1FB6\u1FB7\u1FBE\u1FC2\u1FC3\u1FC4\u1FC6\u1FC7\u1FD0\u1FD1\u1FD2\u1FD3\u1FD6\u1FD7\u1FE0\u1FE1\u1FE2\u1FE3\u1FE4\u1FE5\u1FE6\u1FE7\u1FF2\u1FF3\u1FF4\u1FF6\u1FF7\u2071\u207F\u210A\u210E\u210F\u2113\u212F\u2134\u2139\u213C\u213D\u2146\u2147\u2148\u2149\u214E\u2184\u2C30\u2C31\u2C32\u2C33\u2C34\u2C35\u2C36\u2C37\u2C38\u2C39\u2C3A\u2C3B\u2C3C\u2C3D\u2C3E\u2C3F\u2C40\u2C41\u2C42\u2C43\u2C44\u2C45\u2C46\u2C47\u2C48\u2C49\u2C4A\u2C4B\u2C4C\u2C4D\u2C4E\u2C4F\u2C50\u2C51\u2C52\u2C53\u2C54\u2C55\u2C56\u2C57\u2C58\u2C59\u2C5A\u2C5B\u2C5C\u2C5D\u2C5E\u2C61\u2C65\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73\u2C74\u2C76\u2C77\u2C78\u2C79\u2C7A\u2C7B\u2C7C\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3\u2CE4\u2D00\u2D01\u2D02\u2D03\u2D04\u2D05\u2D06\u2D07\u2D08\u2D09\u2D0A\u2D0B\u2D0C\u2D0D\u2D0E\u2D0F\u2D10\u2D11\u2D12\u2D13\u2D14\u2D15\u2D16\u2D17\u2D18\u2D19\u2D1A\u2D1B\u2D1C\u2D1D\u2D1E\u2D1F\u2D20\u2D21\u2D22\u2D23\u2D24\u2D25\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F\uA730\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771\uA772\uA773\uA774\uA775\uA776\uA777\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uFB00\uFB01\uFB02\uFB03\uFB04\uFB05\uFB06\uFB13\uFB14\uFB15\uFB16\uFB17\uFF41\uFF42\uFF43\uFF44\uFF45\uFF46\uFF47\uFF48\uFF49\uFF4A\uFF4B\uFF4C\uFF4D\uFF4E\uFF4F\uFF50\uFF51\uFF52\uFF53\uFF54\uFF55\uFF56\uFF57\uFF58\uFF59\uFF5A]/,
-      peg$c247 = peg$classExpectation(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "\xAA", "\xB5", "\xBA", "\xDF", "\xE0", "\xE1", "\xE2", "\xE3", "\xE4", "\xE5", "\xE6", "\xE7", "\xE8", "\xE9", "\xEA", "\xEB", "\xEC", "\xED", "\xEE", "\xEF", "\xF0", "\xF1", "\xF2", "\xF3", "\xF4", "\xF5", "\xF6", "\xF8", "\xF9", "\xFA", "\xFB", "\xFC", "\xFD", "\xFE", "\xFF", "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", "\u0137", "\u0138", "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", "\u0148", "\u0149", "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", "\u017E", "\u017F", "\u0180", "\u0183", "\u0185", "\u0188", "\u018C", "\u018D", "\u0192", "\u0195", "\u0199", "\u019A", "\u019B", "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", "\u01AA", "\u01AB", "\u01AD", "\u01B0", "\u01B4", "\u01B6", "\u01B9", "\u01BA", "\u01BD", "\u01BE", "\u01BF", "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", "\u01DC", "\u01DD", "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", "\u01EF", "\u01F0", "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", "\u0233", "\u0234", "\u0235", "\u0236", "\u0237", "\u0238", "\u0239", "\u023C", "\u023F", "\u0240", "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", "\u024F", "\u0250", "\u0251", "\u0252", "\u0253", "\u0254", "\u0255", "\u0256", "\u0257", "\u0258", "\u0259", "\u025A", "\u025B", "\u025C", "\u025D", "\u025E", "\u025F", "\u0260", "\u0261", "\u0262", "\u0263", "\u0264", "\u0265", "\u0266", "\u0267", "\u0268", "\u0269", "\u026A", "\u026B", "\u026C", "\u026D", "\u026E", "\u026F", "\u0270", "\u0271", "\u0272", "\u0273", "\u0274", "\u0275", "\u0276", "\u0277", "\u0278", "\u0279", "\u027A", "\u027B", "\u027C", "\u027D", "\u027E", "\u027F", "\u0280", "\u0281", "\u0282", "\u0283", "\u0284", "\u0285", "\u0286", "\u0287", "\u0288", "\u0289", "\u028A", "\u028B", "\u028C", "\u028D", "\u028E", "\u028F", "\u0290", "\u0291", "\u0292", "\u0293", "\u0295", "\u0296", "\u0297", "\u0298", "\u0299", "\u029A", "\u029B", "\u029C", "\u029D", "\u029E", "\u029F", "\u02A0", "\u02A1", "\u02A2", "\u02A3", "\u02A4", "\u02A5", "\u02A6", "\u02A7", "\u02A8", "\u02A9", "\u02AA", "\u02AB", "\u02AC", "\u02AD", "\u02AE", "\u02AF", "\u0371", "\u0373", "\u0377", "\u037B", "\u037C", "\u037D", "\u0390", "\u03AC", "\u03AD", "\u03AE", "\u03AF", "\u03B0", "\u03B1", "\u03B2", "\u03B3", "\u03B4", "\u03B5", "\u03B6", "\u03B7", "\u03B8", "\u03B9", "\u03BA", "\u03BB", "\u03BC", "\u03BD", "\u03BE", "\u03BF", "\u03C0", "\u03C1", "\u03C2", "\u03C3", "\u03C4", "\u03C5", "\u03C6", "\u03C7", "\u03C8", "\u03C9", "\u03CA", "\u03CB", "\u03CC", "\u03CD", "\u03CE", "\u03D0", "\u03D1", "\u03D5", "\u03D6", "\u03D7", "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", "\u03EF", "\u03F0", "\u03F1", "\u03F2", "\u03F3", "\u03F5", "\u03F8", "\u03FB", "\u03FC", "\u0430", "\u0431", "\u0432", "\u0433", "\u0434", "\u0435", "\u0436", "\u0437", "\u0438", "\u0439", "\u043A", "\u043B", "\u043C", "\u043D", "\u043E", "\u043F", "\u0440", "\u0441", "\u0442", "\u0443", "\u0444", "\u0445", "\u0446", "\u0447", "\u0448", "\u0449", "\u044A", "\u044B", "\u044C", "\u044D", "\u044E", "\u044F", "\u0450", "\u0451", "\u0452", "\u0453", "\u0454", "\u0455", "\u0456", "\u0457", "\u0458", "\u0459", "\u045A", "\u045B", "\u045C", "\u045D", "\u045E", "\u045F", "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", "\u04CE", "\u04CF", "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0561", "\u0562", "\u0563", "\u0564", "\u0565", "\u0566", "\u0567", "\u0568", "\u0569", "\u056A", "\u056B", "\u056C", "\u056D", "\u056E", "\u056F", "\u0570", "\u0571", "\u0572", "\u0573", "\u0574", "\u0575", "\u0576", "\u0577", "\u0578", "\u0579", "\u057A", "\u057B", "\u057C", "\u057D", "\u057E", "\u057F", "\u0580", "\u0581", "\u0582", "\u0583", "\u0584", "\u0585", "\u0586", "\u0587", "\u1D00", "\u1D01", "\u1D02", "\u1D03", "\u1D04", "\u1D05", "\u1D06", "\u1D07", "\u1D08", "\u1D09", "\u1D0A", "\u1D0B", "\u1D0C", "\u1D0D", "\u1D0E", "\u1D0F", "\u1D10", "\u1D11", "\u1D12", "\u1D13", "\u1D14", "\u1D15", "\u1D16", "\u1D17", "\u1D18", "\u1D19", "\u1D1A", "\u1D1B", "\u1D1C", "\u1D1D", "\u1D1E", "\u1D1F", "\u1D20", "\u1D21", "\u1D22", "\u1D23", "\u1D24", "\u1D25", "\u1D26", "\u1D27", "\u1D28", "\u1D29", "\u1D2A", "\u1D2B", "\u1D62", "\u1D63", "\u1D64", "\u1D65", "\u1D66", "\u1D67", "\u1D68", "\u1D69", "\u1D6A", "\u1D6B", "\u1D6C", "\u1D6D", "\u1D6E", "\u1D6F", "\u1D70", "\u1D71", "\u1D72", "\u1D73", "\u1D74", "\u1D75", "\u1D76", "\u1D77", "\u1D79", "\u1D7A", "\u1D7B", "\u1D7C", "\u1D7D", "\u1D7E", "\u1D7F", "\u1D80", "\u1D81", "\u1D82", "\u1D83", "\u1D84", "\u1D85", "\u1D86", "\u1D87", "\u1D88", "\u1D89", "\u1D8A", "\u1D8B", "\u1D8C", "\u1D8D", "\u1D8E", "\u1D8F", "\u1D90", "\u1D91", "\u1D92", "\u1D93", "\u1D94", "\u1D95", "\u1D96", "\u1D97", "\u1D98", "\u1D99", "\u1D9A", "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", "\u1E95", "\u1E96", "\u1E97", "\u1E98", "\u1E99", "\u1E9A", "\u1E9B", "\u1E9C", "\u1E9D", "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", "\u1EFF", "\u1F00", "\u1F01", "\u1F02", "\u1F03", "\u1F04", "\u1F05", "\u1F06", "\u1F07", "\u1F10", "\u1F11", "\u1F12", "\u1F13", "\u1F14", "\u1F15", "\u1F20", "\u1F21", "\u1F22", "\u1F23", "\u1F24", "\u1F25", "\u1F26", "\u1F27", "\u1F30", "\u1F31", "\u1F32", "\u1F33", "\u1F34", "\u1F35", "\u1F36", "\u1F37", "\u1F40", "\u1F41", "\u1F42", "\u1F43", "\u1F44", "\u1F45", "\u1F50", "\u1F51", "\u1F52", "\u1F53", "\u1F54", "\u1F55", "\u1F56", "\u1F57", "\u1F60", "\u1F61", "\u1F62", "\u1F63", "\u1F64", "\u1F65", "\u1F66", "\u1F67", "\u1F70", "\u1F71", "\u1F72", "\u1F73", "\u1F74", "\u1F75", "\u1F76", "\u1F77", "\u1F78", "\u1F79", "\u1F7A", "\u1F7B", "\u1F7C", "\u1F7D", "\u1F80", "\u1F81", "\u1F82", "\u1F83", "\u1F84", "\u1F85", "\u1F86", "\u1F87", "\u1F90", "\u1F91", "\u1F92", "\u1F93", "\u1F94", "\u1F95", "\u1F96", "\u1F97", "\u1FA0", "\u1FA1", "\u1FA2", "\u1FA3", "\u1FA4", "\u1FA5", "\u1FA6", "\u1FA7", "\u1FB0", "\u1FB1", "\u1FB2", "\u1FB3", "\u1FB4", "\u1FB6", "\u1FB7", "\u1FBE", "\u1FC2", "\u1FC3", "\u1FC4", "\u1FC6", "\u1FC7", "\u1FD0", "\u1FD1", "\u1FD2", "\u1FD3", "\u1FD6", "\u1FD7", "\u1FE0", "\u1FE1", "\u1FE2", "\u1FE3", "\u1FE4", "\u1FE5", "\u1FE6", "\u1FE7", "\u1FF2", "\u1FF3", "\u1FF4", "\u1FF6", "\u1FF7", "\u2071", "\u207F", "\u210A", "\u210E", "\u210F", "\u2113", "\u212F", "\u2134", "\u2139", "\u213C", "\u213D", "\u2146", "\u2147", "\u2148", "\u2149", "\u214E", "\u2184", "\u2C30", "\u2C31", "\u2C32", "\u2C33", "\u2C34", "\u2C35", "\u2C36", "\u2C37", "\u2C38", "\u2C39", "\u2C3A", "\u2C3B", "\u2C3C", "\u2C3D", "\u2C3E", "\u2C3F", "\u2C40", "\u2C41", "\u2C42", "\u2C43", "\u2C44", "\u2C45", "\u2C46", "\u2C47", "\u2C48", "\u2C49", "\u2C4A", "\u2C4B", "\u2C4C", "\u2C4D", "\u2C4E", "\u2C4F", "\u2C50", "\u2C51", "\u2C52", "\u2C53", "\u2C54", "\u2C55", "\u2C56", "\u2C57", "\u2C58", "\u2C59", "\u2C5A", "\u2C5B", "\u2C5C", "\u2C5D", "\u2C5E", "\u2C61", "\u2C65", "\u2C66", "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", "\u2C73", "\u2C74", "\u2C76", "\u2C77", "\u2C78", "\u2C79", "\u2C7A", "\u2C7B", "\u2C7C", "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", "\u2CE3", "\u2CE4", "\u2D00", "\u2D01", "\u2D02", "\u2D03", "\u2D04", "\u2D05", "\u2D06", "\u2D07", "\u2D08", "\u2D09", "\u2D0A", "\u2D0B", "\u2D0C", "\u2D0D", "\u2D0E", "\u2D0F", "\u2D10", "\u2D11", "\u2D12", "\u2D13", "\u2D14", "\u2D15", "\u2D16", "\u2D17", "\u2D18", "\u2D19", "\u2D1A", "\u2D1B", "\u2D1C", "\u2D1D", "\u2D1E", "\u2D1F", "\u2D20", "\u2D21", "\u2D22", "\u2D23", "\u2D24", "\u2D25", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", "\uA72F", "\uA730", "\uA731", "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", "\uA771", "\uA772", "\uA773", "\uA774", "\uA775", "\uA776", "\uA777", "\uA778", "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uFB00", "\uFB01", "\uFB02", "\uFB03", "\uFB04", "\uFB05", "\uFB06", "\uFB13", "\uFB14", "\uFB15", "\uFB16", "\uFB17", "\uFF41", "\uFF42", "\uFF43", "\uFF44", "\uFF45", "\uFF46", "\uFF47", "\uFF48", "\uFF49", "\uFF4A", "\uFF4B", "\uFF4C", "\uFF4D", "\uFF4E", "\uFF4F", "\uFF50", "\uFF51", "\uFF52", "\uFF53", "\uFF54", "\uFF55", "\uFF56", "\uFF57", "\uFF58", "\uFF59", "\uFF5A"], false, false),
-      peg$c248 = peg$otherExpectation("Unicode titlecase letter"),
-      peg$c249 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88\u1F89\u1F8A\u1F8B\u1F8C\u1F8D\u1F8E\u1F8F\u1F98\u1F99\u1F9A\u1F9B\u1F9C\u1F9D\u1F9E\u1F9F\u1FA8\u1FA9\u1FAA\u1FAB\u1FAC\u1FAD\u1FAE\u1FAF\u1FBC\u1FCC]/,
-      peg$c250 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", "\u1F88", "\u1F89", "\u1F8A", "\u1F8B", "\u1F8C", "\u1F8D", "\u1F8E", "\u1F8F", "\u1F98", "\u1F99", "\u1F9A", "\u1F9B", "\u1F9C", "\u1F9D", "\u1F9E", "\u1F9F", "\u1FA8", "\u1FA9", "\u1FAA", "\u1FAB", "\u1FAC", "\u1FAD", "\u1FAE", "\u1FAF", "\u1FBC", "\u1FCC"], false, false),
-      peg$c251 = peg$otherExpectation("Unicode modifier letter"),
-      peg$c252 = /^[\u02B0\u02B1\u02B2\u02B3\u02B4\u02B5\u02B6\u02B7\u02B8\u02B9\u02BA\u02BB\u02BC\u02BD\u02BE\u02BF\u02C0\u02C1\u02C6\u02C7\u02C8\u02C9\u02CA\u02CB\u02CC\u02CD\u02CE\u02CF\u02D0\u02D1\u02E0\u02E1\u02E2\u02E3\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5\u06E6\u07F4\u07F5\u07FA\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1C78\u1C79\u1C7A\u1C7B\u1C7C\u1C7D\u1D2C\u1D2D\u1D2E\u1D2F\u1D30\u1D31\u1D32\u1D33\u1D34\u1D35\u1D36\u1D37\u1D38\u1D39\u1D3A\u1D3B\u1D3C\u1D3D\u1D3E\u1D3F\u1D40\u1D41\u1D42\u1D43\u1D44\u1D45\u1D46\u1D47\u1D48\u1D49\u1D4A\u1D4B\u1D4C\u1D4D\u1D4E\u1D4F\u1D50\u1D51\u1D52\u1D53\u1D54\u1D55\u1D56\u1D57\u1D58\u1D59\u1D5A\u1D5B\u1D5C\u1D5D\u1D5E\u1D5F\u1D60\u1D61\u1D78\u1D9B\u1D9C\u1D9D\u1D9E\u1D9F\u1DA0\u1DA1\u1DA2\u1DA3\u1DA4\u1DA5\u1DA6\u1DA7\u1DA8\u1DA9\u1DAA\u1DAB\u1DAC\u1DAD\u1DAE\u1DAF\u1DB0\u1DB1\u1DB2\u1DB3\u1DB4\u1DB5\u1DB6\u1DB7\u1DB8\u1DB9\u1DBA\u1DBB\u1DBC\u1DBD\u1DBE\u1DBF\u2090\u2091\u2092\u2093\u2094\u2C7D\u2D6F\u2E2F\u3005\u3031\u3032\u3033\u3034\u3035\u303B\u309D\u309E\u30FC\u30FD\u30FE\uA015\uA60C\uA67F\uA717\uA718\uA719\uA71A\uA71B\uA71C\uA71D\uA71E\uA71F\uA770\uA788\uFF70\uFF9E\uFF9F]/,
-      peg$c253 = peg$classExpectation(["\u02B0", "\u02B1", "\u02B2", "\u02B3", "\u02B4", "\u02B5", "\u02B6", "\u02B7", "\u02B8", "\u02B9", "\u02BA", "\u02BB", "\u02BC", "\u02BD", "\u02BE", "\u02BF", "\u02C0", "\u02C1", "\u02C6", "\u02C7", "\u02C8", "\u02C9", "\u02CA", "\u02CB", "\u02CC", "\u02CD", "\u02CE", "\u02CF", "\u02D0", "\u02D1", "\u02E0", "\u02E1", "\u02E2", "\u02E3", "\u02E4", "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", "\u06E5", "\u06E6", "\u07F4", "\u07F5", "\u07FA", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1C78", "\u1C79", "\u1C7A", "\u1C7B", "\u1C7C", "\u1C7D", "\u1D2C", "\u1D2D", "\u1D2E", "\u1D2F", "\u1D30", "\u1D31", "\u1D32", "\u1D33", "\u1D34", "\u1D35", "\u1D36", "\u1D37", "\u1D38", "\u1D39", "\u1D3A", "\u1D3B", "\u1D3C", "\u1D3D", "\u1D3E", "\u1D3F", "\u1D40", "\u1D41", "\u1D42", "\u1D43", "\u1D44", "\u1D45", "\u1D46", "\u1D47", "\u1D48", "\u1D49", "\u1D4A", "\u1D4B", "\u1D4C", "\u1D4D", "\u1D4E", "\u1D4F", "\u1D50", "\u1D51", "\u1D52", "\u1D53", "\u1D54", "\u1D55", "\u1D56", "\u1D57", "\u1D58", "\u1D59", "\u1D5A", "\u1D5B", "\u1D5C", "\u1D5D", "\u1D5E", "\u1D5F", "\u1D60", "\u1D61", "\u1D78", "\u1D9B", "\u1D9C", "\u1D9D", "\u1D9E", "\u1D9F", "\u1DA0", "\u1DA1", "\u1DA2", "\u1DA3", "\u1DA4", "\u1DA5", "\u1DA6", "\u1DA7", "\u1DA8", "\u1DA9", "\u1DAA", "\u1DAB", "\u1DAC", "\u1DAD", "\u1DAE", "\u1DAF", "\u1DB0", "\u1DB1", "\u1DB2", "\u1DB3", "\u1DB4", "\u1DB5", "\u1DB6", "\u1DB7", "\u1DB8", "\u1DB9", "\u1DBA", "\u1DBB", "\u1DBC", "\u1DBD", "\u1DBE", "\u1DBF", "\u2090", "\u2091", "\u2092", "\u2093", "\u2094", "\u2C7D", "\u2D6F", "\u2E2F", "\u3005", "\u3031", "\u3032", "\u3033", "\u3034", "\u3035", "\u303B", "\u309D", "\u309E", "\u30FC", "\u30FD", "\u30FE", "\uA015", "\uA60C", "\uA67F", "\uA717", "\uA718", "\uA719", "\uA71A", "\uA71B", "\uA71C", "\uA71D", "\uA71E", "\uA71F", "\uA770", "\uA788", "\uFF70", "\uFF9E", "\uFF9F"], false, false),
-      peg$c254 = peg$otherExpectation("Unicode other letter"),
-      peg$c255 = /^[\u01BB\u01C0\u01C1\u01C2\u01C3\u0294\u05D0\u05D1\u05D2\u05D3\u05D4\u05D5\u05D6\u05D7\u05D8\u05D9\u05DA\u05DB\u05DC\u05DD\u05DE\u05DF\u05E0\u05E1\u05E2\u05E3\u05E4\u05E5\u05E6\u05E7\u05E8\u05E9\u05EA\u05F0\u05F1\u05F2\u0621\u0622\u0623\u0624\u0625\u0626\u0627\u0628\u0629\u062A\u062B\u062C\u062D\u062E\u062F\u0630\u0631\u0632\u0633\u0634\u0635\u0636\u0637\u0638\u0639\u063A\u063B\u063C\u063D\u063E\u063F\u0641\u0642\u0643\u0644\u0645\u0646\u0647\u0648\u0649\u064A\u066E\u066F\u0671\u0672\u0673\u0674\u0675\u0676\u0677\u0678\u0679\u067A\u067B\u067C\u067D\u067E\u067F\u0680\u0681\u0682\u0683\u0684\u0685\u0686\u0687\u0688\u0689\u068A\u068B\u068C\u068D\u068E\u068F\u0690\u0691\u0692\u0693\u0694\u0695\u0696\u0697\u0698\u0699\u069A\u069B\u069C\u069D\u069E\u069F\u06A0\u06A1\u06A2\u06A3\u06A4\u06A5\u06A6\u06A7\u06A8\u06A9\u06AA\u06AB\u06AC\u06AD\u06AE\u06AF\u06B0\u06B1\u06B2\u06B3\u06B4\u06B5\u06B6\u06B7\u06B8\u06B9\u06BA\u06BB\u06BC\u06BD\u06BE\u06BF\u06C0\u06C1\u06C2\u06C3\u06C4\u06C5\u06C6\u06C7\u06C8\u06C9\u06CA\u06CB\u06CC\u06CD\u06CE\u06CF\u06D0\u06D1\u06D2\u06D3\u06D5\u06EE\u06EF\u06FA\u06FB\u06FC\u06FF\u0710\u0712\u0713\u0714\u0715\u0716\u0717\u0718\u0719\u071A\u071B\u071C\u071D\u071E\u071F\u0720\u0721\u0722\u0723\u0724\u0725\u0726\u0727\u0728\u0729\u072A\u072B\u072C\u072D\u072E\u072F\u074D\u074E\u074F\u0750\u0751\u0752\u0753\u0754\u0755\u0756\u0757\u0758\u0759\u075A\u075B\u075C\u075D\u075E\u075F\u0760\u0761\u0762\u0763\u0764\u0765\u0766\u0767\u0768\u0769\u076A\u076B\u076C\u076D\u076E\u076F\u0770\u0771\u0772\u0773\u0774\u0775\u0776\u0777\u0778\u0779\u077A\u077B\u077C\u077D\u077E\u077F\u0780\u0781\u0782\u0783\u0784\u0785\u0786\u0787\u0788\u0789\u078A\u078B\u078C\u078D\u078E\u078F\u0790\u0791\u0792\u0793\u0794\u0795\u0796\u0797\u0798\u0799\u079A\u079B\u079C\u079D\u079E\u079F\u07A0\u07A1\u07A2\u07A3\u07A4\u07A5\u07B1\u07CA\u07CB\u07CC\u07CD\u07CE\u07CF\u07D0\u07D1\u07D2\u07D3\u07D4\u07D5\u07D6\u07D7\u07D8\u07D9\u07DA\u07DB\u07DC\u07DD\u07DE\u07DF\u07E0\u07E1\u07E2\u07E3\u07E4\u07E5\u07E6\u07E7\u07E8\u07E9\u07EA\u0904\u0905\u0906\u0907\u0908\u0909\u090A\u090B\u090C\u090D\u090E\u090F\u0910\u0911\u0912\u0913\u0914\u0915\u0916\u0917\u0918\u0919\u091A\u091B\u091C\u091D\u091E\u091F\u0920\u0921\u0922\u0923\u0924\u0925\u0926\u0927\u0928\u0929\u092A\u092B\u092C\u092D\u092E\u092F\u0930\u0931\u0932\u0933\u0934\u0935\u0936\u0937\u0938\u0939\u093D\u0950\u0958\u0959\u095A\u095B\u095C\u095D\u095E\u095F\u0960\u0961\u0972\u097B\u097C\u097D\u097E\u097F\u0985\u0986\u0987\u0988\u0989\u098A\u098B\u098C\u098F\u0990\u0993\u0994\u0995\u0996\u0997\u0998\u0999\u099A\u099B\u099C\u099D\u099E\u099F\u09A0\u09A1\u09A2\u09A3\u09A4\u09A5\u09A6\u09A7\u09A8\u09AA\u09AB\u09AC\u09AD\u09AE\u09AF\u09B0\u09B2\u09B6\u09B7\u09B8\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF\u09E0\u09E1\u09F0\u09F1\u0A05\u0A06\u0A07\u0A08\u0A09\u0A0A\u0A0F\u0A10\u0A13\u0A14\u0A15\u0A16\u0A17\u0A18\u0A19\u0A1A\u0A1B\u0A1C\u0A1D\u0A1E\u0A1F\u0A20\u0A21\u0A22\u0A23\u0A24\u0A25\u0A26\u0A27\u0A28\u0A2A\u0A2B\u0A2C\u0A2D\u0A2E\u0A2F\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59\u0A5A\u0A5B\u0A5C\u0A5E\u0A72\u0A73\u0A74\u0A85\u0A86\u0A87\u0A88\u0A89\u0A8A\u0A8B\u0A8C\u0A8D\u0A8F\u0A90\u0A91\u0A93\u0A94\u0A95\u0A96\u0A97\u0A98\u0A99\u0A9A\u0A9B\u0A9C\u0A9D\u0A9E\u0A9F\u0AA0\u0AA1\u0AA2\u0AA3\u0AA4\u0AA5\u0AA6\u0AA7\u0AA8\u0AAA\u0AAB\u0AAC\u0AAD\u0AAE\u0AAF\u0AB0\u0AB2\u0AB3\u0AB5\u0AB6\u0AB7\u0AB8\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0B05\u0B06\u0B07\u0B08\u0B09\u0B0A\u0B0B\u0B0C\u0B0F\u0B10\u0B13\u0B14\u0B15\u0B16\u0B17\u0B18\u0B19\u0B1A\u0B1B\u0B1C\u0B1D\u0B1E\u0B1F\u0B20\u0B21\u0B22\u0B23\u0B24\u0B25\u0B26\u0B27\u0B28\u0B2A\u0B2B\u0B2C\u0B2D\u0B2E\u0B2F\u0B30\u0B32\u0B33\u0B35\u0B36\u0B37\u0B38\u0B39\u0B3D\u0B5C\u0B5D\u0B5F\u0B60\u0B61\u0B71\u0B83\u0B85\u0B86\u0B87\u0B88\u0B89\u0B8A\u0B8E\u0B8F\u0B90\u0B92\u0B93\u0B94\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8\u0BA9\u0BAA\u0BAE\u0BAF\u0BB0\u0BB1\u0BB2\u0BB3\u0BB4\u0BB5\u0BB6\u0BB7\u0BB8\u0BB9\u0BD0\u0C05\u0C06\u0C07\u0C08\u0C09\u0C0A\u0C0B\u0C0C\u0C0E\u0C0F\u0C10\u0C12\u0C13\u0C14\u0C15\u0C16\u0C17\u0C18\u0C19\u0C1A\u0C1B\u0C1C\u0C1D\u0C1E\u0C1F\u0C20\u0C21\u0C22\u0C23\u0C24\u0C25\u0C26\u0C27\u0C28\u0C2A\u0C2B\u0C2C\u0C2D\u0C2E\u0C2F\u0C30\u0C31\u0C32\u0C33\u0C35\u0C36\u0C37\u0C38\u0C39\u0C3D\u0C58\u0C59\u0C60\u0C61\u0C85\u0C86\u0C87\u0C88\u0C89\u0C8A\u0C8B\u0C8C\u0C8E\u0C8F\u0C90\u0C92\u0C93\u0C94\u0C95\u0C96\u0C97\u0C98\u0C99\u0C9A\u0C9B\u0C9C\u0C9D\u0C9E\u0C9F\u0CA0\u0CA1\u0CA2\u0CA3\u0CA4\u0CA5\u0CA6\u0CA7\u0CA8\u0CAA\u0CAB\u0CAC\u0CAD\u0CAE\u0CAF\u0CB0\u0CB1\u0CB2\u0CB3\u0CB5\u0CB6\u0CB7\u0CB8\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0D05\u0D06\u0D07\u0D08\u0D09\u0D0A\u0D0B\u0D0C\u0D0E\u0D0F\u0D10\u0D12\u0D13\u0D14\u0D15\u0D16\u0D17\u0D18\u0D19\u0D1A\u0D1B\u0D1C\u0D1D\u0D1E\u0D1F\u0D20\u0D21\u0D22\u0D23\u0D24\u0D25\u0D26\u0D27\u0D28\u0D2A\u0D2B\u0D2C\u0D2D\u0D2E\u0D2F\u0D30\u0D31\u0D32\u0D33\u0D34\u0D35\u0D36\u0D37\u0D38\u0D39\u0D3D\u0D60\u0D61\u0D7A\u0D7B\u0D7C\u0D7D\u0D7E\u0D7F\u0D85\u0D86\u0D87\u0D88\u0D89\u0D8A\u0D8B\u0D8C\u0D8D\u0D8E\u0D8F\u0D90\u0D91\u0D92\u0D93\u0D94\u0D95\u0D96\u0D9A\u0D9B\u0D9C\u0D9D\u0D9E\u0D9F\u0DA0\u0DA1\u0DA2\u0DA3\u0DA4\u0DA5\u0DA6\u0DA7\u0DA8\u0DA9\u0DAA\u0DAB\u0DAC\u0DAD\u0DAE\u0DAF\u0DB0\u0DB1\u0DB3\u0DB4\u0DB5\u0DB6\u0DB7\u0DB8\u0DB9\u0DBA\u0DBB\u0DBD\u0DC0\u0DC1\u0DC2\u0DC3\u0DC4\u0DC5\u0DC6\u0E01\u0E02\u0E03\u0E04\u0E05\u0E06\u0E07\u0E08\u0E09\u0E0A\u0E0B\u0E0C\u0E0D\u0E0E\u0E0F\u0E10\u0E11\u0E12\u0E13\u0E14\u0E15\u0E16\u0E17\u0E18\u0E19\u0E1A\u0E1B\u0E1C\u0E1D\u0E1E\u0E1F\u0E20\u0E21\u0E22\u0E23\u0E24\u0E25\u0E26\u0E27\u0E28\u0E29\u0E2A\u0E2B\u0E2C\u0E2D\u0E2E\u0E2F\u0E30\u0E32\u0E33\u0E40\u0E41\u0E42\u0E43\u0E44\u0E45\u0E81\u0E82\u0E84\u0E87\u0E88\u0E8A\u0E8D\u0E94\u0E95\u0E96\u0E97\u0E99\u0E9A\u0E9B\u0E9C\u0E9D\u0E9E\u0E9F\u0EA1\u0EA2\u0EA3\u0EA5\u0EA7\u0EAA\u0EAB\u0EAD\u0EAE\u0EAF\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0\u0EC1\u0EC2\u0EC3\u0EC4\u0EDC\u0EDD\u0F00\u0F40\u0F41\u0F42\u0F43\u0F44\u0F45\u0F46\u0F47\u0F49\u0F4A\u0F4B\u0F4C\u0F4D\u0F4E\u0F4F\u0F50\u0F51\u0F52\u0F53\u0F54\u0F55\u0F56\u0F57\u0F58\u0F59\u0F5A\u0F5B\u0F5C\u0F5D\u0F5E\u0F5F\u0F60\u0F61\u0F62\u0F63\u0F64\u0F65\u0F66\u0F67\u0F68\u0F69\u0F6A\u0F6B\u0F6C\u0F88\u0F89\u0F8A\u0F8B\u1000\u1001\u1002\u1003\u1004\u1005\u1006\u1007\u1008\u1009\u100A\u100B\u100C\u100D\u100E\u100F\u1010\u1011\u1012\u1013\u1014\u1015\u1016\u1017\u1018\u1019\u101A\u101B\u101C\u101D\u101E\u101F\u1020\u1021\u1022\u1023\u1024\u1025\u1026\u1027\u1028\u1029\u102A\u103F\u1050\u1051\u1052\u1053\u1054\u1055\u105A\u105B\u105C\u105D\u1061\u1065\u1066\u106E\u106F\u1070\u1075\u1076\u1077\u1078\u1079\u107A\u107B\u107C\u107D\u107E\u107F\u1080\u1081\u108E\u10D0\u10D1\u10D2\u10D3\u10D4\u10D5\u10D6\u10D7\u10D8\u10D9\u10DA\u10DB\u10DC\u10DD\u10DE\u10DF\u10E0\u10E1\u10E2\u10E3\u10E4\u10E5\u10E6\u10E7\u10E8\u10E9\u10EA\u10EB\u10EC\u10ED\u10EE\u10EF\u10F0\u10F1\u10F2\u10F3\u10F4\u10F5\u10F6\u10F7\u10F8\u10F9\u10FA\u1100\u1101\u1102\u1103\u1104\u1105\u1106\u1107\u1108\u1109\u110A\u110B\u110C\u110D\u110E\u110F\u1110\u1111\u1112\u1113\u1114\u1115\u1116\u1117\u1118\u1119\u111A\u111B\u111C\u111D\u111E\u111F\u1120\u1121\u1122\u1123\u1124\u1125\u1126\u1127\u1128\u1129\u112A\u112B\u112C\u112D\u112E\u112F\u1130\u1131\u1132\u1133\u1134\u1135\u1136\u1137\u1138\u1139\u113A\u113B\u113C\u113D\u113E\u113F\u1140\u1141\u1142\u1143\u1144\u1145\u1146\u1147\u1148\u1149\u114A\u114B\u114C\u114D\u114E\u114F\u1150\u1151\u1152\u1153\u1154\u1155\u1156\u1157\u1158\u1159\u115F\u1160\u1161\u1162\u1163\u1164\u1165\u1166\u1167\u1168\u1169\u116A\u116B\u116C\u116D\u116E\u116F\u1170\u1171\u1172\u1173\u1174\u1175\u1176\u1177\u1178\u1179\u117A\u117B\u117C\u117D\u117E\u117F\u1180\u1181\u1182\u1183\u1184\u1185\u1186\u1187\u1188\u1189\u118A\u118B\u118C\u118D\u118E\u118F\u1190\u1191\u1192\u1193\u1194\u1195\u1196\u1197\u1198\u1199\u119A\u119B\u119C\u119D\u119E\u119F\u11A0\u11A1\u11A2\u11A8\u11A9\u11AA\u11AB\u11AC\u11AD\u11AE\u11AF\u11B0\u11B1\u11B2\u11B3\u11B4\u11B5\u11B6\u11B7\u11B8\u11B9\u11BA\u11BB\u11BC\u11BD\u11BE\u11BF\u11C0\u11C1\u11C2\u11C3\u11C4\u11C5\u11C6\u11C7\u11C8\u11C9\u11CA\u11CB\u11CC\u11CD\u11CE\u11CF\u11D0\u11D1\u11D2\u11D3\u11D4\u11D5\u11D6\u11D7\u11D8\u11D9\u11DA\u11DB\u11DC\u11DD\u11DE\u11DF\u11E0\u11E1\u11E2\u11E3\u11E4\u11E5\u11E6\u11E7\u11E8\u11E9\u11EA\u11EB\u11EC\u11ED\u11EE\u11EF\u11F0\u11F1\u11F2\u11F3\u11F4\u11F5\u11F6\u11F7\u11F8\u11F9\u1200\u1201\u1202\u1203\u1204\u1205\u1206\u1207\u1208\u1209\u120A\u120B\u120C\u120D\u120E\u120F\u1210\u1211\u1212\u1213\u1214\u1215\u1216\u1217\u1218\u1219\u121A\u121B\u121C\u121D\u121E\u121F\u1220\u1221\u1222\u1223\u1224\u1225\u1226\u1227\u1228\u1229\u122A\u122B\u122C\u122D\u122E\u122F\u1230\u1231\u1232\u1233\u1234\u1235\u1236\u1237\u1238\u1239\u123A\u123B\u123C\u123D\u123E\u123F\u1240\u1241\u1242\u1243\u1244\u1245\u1246\u1247\u1248\u124A\u124B\u124C\u124D\u1250\u1251\u1252\u1253\u1254\u1255\u1256\u1258\u125A\u125B\u125C\u125D\u1260\u1261\u1262\u1263\u1264\u1265\u1266\u1267\u1268\u1269\u126A\u126B\u126C\u126D\u126E\u126F\u1270\u1271\u1272\u1273\u1274\u1275\u1276\u1277\u1278\u1279\u127A\u127B\u127C\u127D\u127E\u127F\u1280\u1281\u1282\u1283\u1284\u1285\u1286\u1287\u1288\u128A\u128B\u128C\u128D\u1290\u1291\u1292\u1293\u1294\u1295\u1296\u1297\u1298\u1299\u129A\u129B\u129C\u129D\u129E\u129F\u12A0\u12A1\u12A2\u12A3\u12A4\u12A5\u12A6\u12A7\u12A8\u12A9\u12AA\u12AB\u12AC\u12AD\u12AE\u12AF\u12B0\u12B2\u12B3\u12B4\u12B5\u12B8\u12B9\u12BA\u12BB\u12BC\u12BD\u12BE\u12C0\u12C2\u12C3\u12C4\u12C5\u12C8\u12C9\u12CA\u12CB\u12CC\u12CD\u12CE\u12CF\u12D0\u12D1\u12D2\u12D3\u12D4\u12D5\u12D6\u12D8\u12D9\u12DA\u12DB\u12DC\u12DD\u12DE\u12DF\u12E0\u12E1\u12E2\u12E3\u12E4\u12E5\u12E6\u12E7\u12E8\u12E9\u12EA\u12EB\u12EC\u12ED\u12EE\u12EF\u12F0\u12F1\u12F2\u12F3\u12F4\u12F5\u12F6\u12F7\u12F8\u12F9\u12FA\u12FB\u12FC\u12FD\u12FE\u12FF\u1300\u1301\u1302\u1303\u1304\u1305\u1306\u1307\u1308\u1309\u130A\u130B\u130C\u130D\u130E\u130F\u1310\u1312\u1313\u1314\u1315\u1318\u1319\u131A\u131B\u131C\u131D\u131E\u131F\u1320\u1321\u1322\u1323\u1324\u1325\u1326\u1327\u1328\u1329\u132A\u132B\u132C\u132D\u132E\u132F\u1330\u1331\u1332\u1333\u1334\u1335\u1336\u1337\u1338\u1339\u133A\u133B\u133C\u133D\u133E\u133F\u1340\u1341\u1342\u1343\u1344\u1345\u1346\u1347\u1348\u1349\u134A\u134B\u134C\u134D\u134E\u134F\u1350\u1351\u1352\u1353\u1354\u1355\u1356\u1357\u1358\u1359\u135A\u1380\u1381\u1382\u1383\u1384\u1385\u1386\u1387\u1388\u1389\u138A\u138B\u138C\u138D\u138E\u138F\u13A0\u13A1\u13A2\u13A3\u13A4\u13A5\u13A6\u13A7\u13A8\u13A9\u13AA\u13AB\u13AC\u13AD\u13AE\u13AF\u13B0\u13B1\u13B2\u13B3\u13B4\u13B5\u13B6\u13B7\u13B8\u13B9\u13BA\u13BB\u13BC\u13BD\u13BE\u13BF\u13C0\u13C1\u13C2\u13C3\u13C4\u13C5\u13C6\u13C7\u13C8\u13C9\u13CA\u13CB\u13CC\u13CD\u13CE\u13CF\u13D0\u13D1\u13D2\u13D3\u13D4\u13D5\u13D6\u13D7\u13D8\u13D9\u13DA\u13DB\u13DC\u13DD\u13DE\u13DF\u13E0\u13E1\u13E2\u13E3\u13E4\u13E5\u13E6\u13E7\u13E8\u13E9\u13EA\u13EB\u13EC\u13ED\u13EE\u13EF\u13F0\u13F1\u13F2\u13F3\u13F4\u1401\u1402\u1403\u1404\u1405\u1406\u1407\u1408\u1409\u140A\u140B\u140C\u140D\u140E\u140F\u1410\u1411\u1412\u1413\u1414\u1415\u1416\u1417\u1418\u1419\u141A\u141B\u141C\u141D\u141E\u141F\u1420\u1421\u1422\u1423\u1424\u1425\u1426\u1427\u1428\u1429\u142A\u142B\u142C\u142D\u142E\u142F\u1430\u1431\u1432\u1433\u1434\u1435\u1436\u1437\u1438\u1439\u143A\u143B\u143C\u143D\u143E\u143F\u1440\u1441\u1442\u1443\u1444\u1445\u1446\u1447\u1448\u1449\u144A\u144B\u144C\u144D\u144E\u144F\u1450\u1451\u1452\u1453\u1454\u1455\u1456\u1457\u1458\u1459\u145A\u145B\u145C\u145D\u145E\u145F\u1460\u1461\u1462\u1463\u1464\u1465\u1466\u1467\u1468\u1469\u146A\u146B\u146C\u146D\u146E\u146F\u1470\u1471\u1472\u1473\u1474\u1475\u1476\u1477\u1478\u1479\u147A\u147B\u147C\u147D\u147E\u147F\u1480\u1481\u1482\u1483\u1484\u1485\u1486\u1487\u1488\u1489\u148A\u148B\u148C\u148D\u148E\u148F\u1490\u1491\u1492\u1493\u1494\u1495\u1496\u1497\u1498\u1499\u149A\u149B\u149C\u149D\u149E\u149F\u14A0\u14A1\u14A2\u14A3\u14A4\u14A5\u14A6\u14A7\u14A8\u14A9\u14AA\u14AB\u14AC\u14AD\u14AE\u14AF\u14B0\u14B1\u14B2\u14B3\u14B4\u14B5\u14B6\u14B7\u14B8\u14B9\u14BA\u14BB\u14BC\u14BD\u14BE\u14BF\u14C0\u14C1\u14C2\u14C3\u14C4\u14C5\u14C6\u14C7\u14C8\u14C9\u14CA\u14CB\u14CC\u14CD\u14CE\u14CF\u14D0\u14D1\u14D2\u14D3\u14D4\u14D5\u14D6\u14D7\u14D8\u14D9\u14DA\u14DB\u14DC\u14DD\u14DE\u14DF\u14E0\u14E1\u14E2\u14E3\u14E4\u14E5\u14E6\u14E7\u14E8\u14E9\u14EA\u14EB\u14EC\u14ED\u14EE\u14EF\u14F0\u14F1\u14F2\u14F3\u14F4\u14F5\u14F6\u14F7\u14F8\u14F9\u14FA\u14FB\u14FC\u14FD\u14FE\u14FF\u1500\u1501\u1502\u1503\u1504\u1505\u1506\u1507\u1508\u1509\u150A\u150B\u150C\u150D\u150E\u150F\u1510\u1511\u1512\u1513\u1514\u1515\u1516\u1517\u1518\u1519\u151A\u151B\u151C\u151D\u151E\u151F\u1520\u1521\u1522\u1523\u1524\u1525\u1526\u1527\u1528\u1529\u152A\u152B\u152C\u152D\u152E\u152F\u1530\u1531\u1532\u1533\u1534\u1535\u1536\u1537\u1538\u1539\u153A\u153B\u153C\u153D\u153E\u153F\u1540\u1541\u1542\u1543\u1544\u1545\u1546\u1547\u1548\u1549\u154A\u154B\u154C\u154D\u154E\u154F\u1550\u1551\u1552\u1553\u1554\u1555\u1556\u1557\u1558\u1559\u155A\u155B\u155C\u155D\u155E\u155F\u1560\u1561\u1562\u1563\u1564\u1565\u1566\u1567\u1568\u1569\u156A\u156B\u156C\u156D\u156E\u156F\u1570\u1571\u1572\u1573\u1574\u1575\u1576\u1577\u1578\u1579\u157A\u157B\u157C\u157D\u157E\u157F\u1580\u1581\u1582\u1583\u1584\u1585\u1586\u1587\u1588\u1589\u158A\u158B\u158C\u158D\u158E\u158F\u1590\u1591\u1592\u1593\u1594\u1595\u1596\u1597\u1598\u1599\u159A\u159B\u159C\u159D\u159E\u159F\u15A0\u15A1\u15A2\u15A3\u15A4\u15A5\u15A6\u15A7\u15A8\u15A9\u15AA\u15AB\u15AC\u15AD\u15AE\u15AF\u15B0\u15B1\u15B2\u15B3\u15B4\u15B5\u15B6\u15B7\u15B8\u15B9\u15BA\u15BB\u15BC\u15BD\u15BE\u15BF\u15C0\u15C1\u15C2\u15C3\u15C4\u15C5\u15C6\u15C7\u15C8\u15C9\u15CA\u15CB\u15CC\u15CD\u15CE\u15CF\u15D0\u15D1\u15D2\u15D3\u15D4\u15D5\u15D6\u15D7\u15D8\u15D9\u15DA\u15DB\u15DC\u15DD\u15DE\u15DF\u15E0\u15E1\u15E2\u15E3\u15E4\u15E5\u15E6\u15E7\u15E8\u15E9\u15EA\u15EB\u15EC\u15ED\u15EE\u15EF\u15F0\u15F1\u15F2\u15F3\u15F4\u15F5\u15F6\u15F7\u15F8\u15F9\u15FA\u15FB\u15FC\u15FD\u15FE\u15FF\u1600\u1601\u1602\u1603\u1604\u1605\u1606\u1607\u1608\u1609\u160A\u160B\u160C\u160D\u160E\u160F\u1610\u1611\u1612\u1613\u1614\u1615\u1616\u1617\u1618\u1619\u161A\u161B\u161C\u161D\u161E\u161F\u1620\u1621\u1622\u1623\u1624\u1625\u1626\u1627\u1628\u1629\u162A\u162B\u162C\u162D\u162E\u162F\u1630\u1631\u1632\u1633\u1634\u1635\u1636\u1637\u1638\u1639\u163A\u163B\u163C\u163D\u163E\u163F\u1640\u1641\u1642\u1643\u1644\u1645\u1646\u1647\u1648\u1649\u164A\u164B\u164C\u164D\u164E\u164F\u1650\u1651\u1652\u1653\u1654\u1655\u1656\u1657\u1658\u1659\u165A\u165B\u165C\u165D\u165E\u165F\u1660\u1661\u1662\u1663\u1664\u1665\u1666\u1667\u1668\u1669\u166A\u166B\u166C\u166F\u1670\u1671\u1672\u1673\u1674\u1675\u1676\u1681\u1682\u1683\u1684\u1685\u1686\u1687\u1688\u1689\u168A\u168B\u168C\u168D\u168E\u168F\u1690\u1691\u1692\u1693\u1694\u1695\u1696\u1697\u1698\u1699\u169A\u16A0\u16A1\u16A2\u16A3\u16A4\u16A5\u16A6\u16A7\u16A8\u16A9\u16AA\u16AB\u16AC\u16AD\u16AE\u16AF\u16B0\u16B1\u16B2\u16B3\u16B4\u16B5\u16B6\u16B7\u16B8\u16B9\u16BA\u16BB\u16BC\u16BD\u16BE\u16BF\u16C0\u16C1\u16C2\u16C3\u16C4\u16C5\u16C6\u16C7\u16C8\u16C9\u16CA\u16CB\u16CC\u16CD\u16CE\u16CF\u16D0\u16D1\u16D2\u16D3\u16D4\u16D5\u16D6\u16D7\u16D8\u16D9\u16DA\u16DB\u16DC\u16DD\u16DE\u16DF\u16E0\u16E1\u16E2\u16E3\u16E4\u16E5\u16E6\u16E7\u16E8\u16E9\u16EA\u1700\u1701\u1702\u1703\u1704\u1705\u1706\u1707\u1708\u1709\u170A\u170B\u170C\u170E\u170F\u1710\u1711\u1720\u1721\u1722\u1723\u1724\u1725\u1726\u1727\u1728\u1729\u172A\u172B\u172C\u172D\u172E\u172F\u1730\u1731\u1740\u1741\u1742\u1743\u1744\u1745\u1746\u1747\u1748\u1749\u174A\u174B\u174C\u174D\u174E\u174F\u1750\u1751\u1760\u1761\u1762\u1763\u1764\u1765\u1766\u1767\u1768\u1769\u176A\u176B\u176C\u176E\u176F\u1770\u1780\u1781\u1782\u1783\u1784\u1785\u1786\u1787\u1788\u1789\u178A\u178B\u178C\u178D\u178E\u178F\u1790\u1791\u1792\u1793\u1794\u1795\u1796\u1797\u1798\u1799\u179A\u179B\u179C\u179D\u179E\u179F\u17A0\u17A1\u17A2\u17A3\u17A4\u17A5\u17A6\u17A7\u17A8\u17A9\u17AA\u17AB\u17AC\u17AD\u17AE\u17AF\u17B0\u17B1\u17B2\u17B3\u17DC\u1820\u1821\u1822\u1823\u1824\u1825\u1826\u1827\u1828\u1829\u182A\u182B\u182C\u182D\u182E\u182F\u1830\u1831\u1832\u1833\u1834\u1835\u1836\u1837\u1838\u1839\u183A\u183B\u183C\u183D\u183E\u183F\u1840\u1841\u1842\u1844\u1845\u1846\u1847\u1848\u1849\u184A\u184B\u184C\u184D\u184E\u184F\u1850\u1851\u1852\u1853\u1854\u1855\u1856\u1857\u1858\u1859\u185A\u185B\u185C\u185D\u185E\u185F\u1860\u1861\u1862\u1863\u1864\u1865\u1866\u1867\u1868\u1869\u186A\u186B\u186C\u186D\u186E\u186F\u1870\u1871\u1872\u1873\u1874\u1875\u1876\u1877\u1880\u1881\u1882\u1883\u1884\u1885\u1886\u1887\u1888\u1889\u188A\u188B\u188C\u188D\u188E\u188F\u1890\u1891\u1892\u1893\u1894\u1895\u1896\u1897\u1898\u1899\u189A\u189B\u189C\u189D\u189E\u189F\u18A0\u18A1\u18A2\u18A3\u18A4\u18A5\u18A6\u18A7\u18A8\u18AA\u1900\u1901\u1902\u1903\u1904\u1905\u1906\u1907\u1908\u1909\u190A\u190B\u190C\u190D\u190E\u190F\u1910\u1911\u1912\u1913\u1914\u1915\u1916\u1917\u1918\u1919\u191A\u191B\u191C\u1950\u1951\u1952\u1953\u1954\u1955\u1956\u1957\u1958\u1959\u195A\u195B\u195C\u195D\u195E\u195F\u1960\u1961\u1962\u1963\u1964\u1965\u1966\u1967\u1968\u1969\u196A\u196B\u196C\u196D\u1970\u1971\u1972\u1973\u1974\u1980\u1981\u1982\u1983\u1984\u1985\u1986\u1987\u1988\u1989\u198A\u198B\u198C\u198D\u198E\u198F\u1990\u1991\u1992\u1993\u1994\u1995\u1996\u1997\u1998\u1999\u199A\u199B\u199C\u199D\u199E\u199F\u19A0\u19A1\u19A2\u19A3\u19A4\u19A5\u19A6\u19A7\u19A8\u19A9\u19C1\u19C2\u19C3\u19C4\u19C5\u19C6\u19C7\u1A00\u1A01\u1A02\u1A03\u1A04\u1A05\u1A06\u1A07\u1A08\u1A09\u1A0A\u1A0B\u1A0C\u1A0D\u1A0E\u1A0F\u1A10\u1A11\u1A12\u1A13\u1A14\u1A15\u1A16\u1B05\u1B06\u1B07\u1B08\u1B09\u1B0A\u1B0B\u1B0C\u1B0D\u1B0E\u1B0F\u1B10\u1B11\u1B12\u1B13\u1B14\u1B15\u1B16\u1B17\u1B18\u1B19\u1B1A\u1B1B\u1B1C\u1B1D\u1B1E\u1B1F\u1B20\u1B21\u1B22\u1B23\u1B24\u1B25\u1B26\u1B27\u1B28\u1B29\u1B2A\u1B2B\u1B2C\u1B2D\u1B2E\u1B2F\u1B30\u1B31\u1B32\u1B33\u1B45\u1B46\u1B47\u1B48\u1B49\u1B4A\u1B4B\u1B83\u1B84\u1B85\u1B86\u1B87\u1B88\u1B89\u1B8A\u1B8B\u1B8C\u1B8D\u1B8E\u1B8F\u1B90\u1B91\u1B92\u1B93\u1B94\u1B95\u1B96\u1B97\u1B98\u1B99\u1B9A\u1B9B\u1B9C\u1B9D\u1B9E\u1B9F\u1BA0\u1BAE\u1BAF\u1C00\u1C01\u1C02\u1C03\u1C04\u1C05\u1C06\u1C07\u1C08\u1C09\u1C0A\u1C0B\u1C0C\u1C0D\u1C0E\u1C0F\u1C10\u1C11\u1C12\u1C13\u1C14\u1C15\u1C16\u1C17\u1C18\u1C19\u1C1A\u1C1B\u1C1C\u1C1D\u1C1E\u1C1F\u1C20\u1C21\u1C22\u1C23\u1C4D\u1C4E\u1C4F\u1C5A\u1C5B\u1C5C\u1C5D\u1C5E\u1C5F\u1C60\u1C61\u1C62\u1C63\u1C64\u1C65\u1C66\u1C67\u1C68\u1C69\u1C6A\u1C6B\u1C6C\u1C6D\u1C6E\u1C6F\u1C70\u1C71\u1C72\u1C73\u1C74\u1C75\u1C76\u1C77\u2135\u2136\u2137\u2138\u2D30\u2D31\u2D32\u2D33\u2D34\u2D35\u2D36\u2D37\u2D38\u2D39\u2D3A\u2D3B\u2D3C\u2D3D\u2D3E\u2D3F\u2D40\u2D41\u2D42\u2D43\u2D44\u2D45\u2D46\u2D47\u2D48\u2D49\u2D4A\u2D4B\u2D4C\u2D4D\u2D4E\u2D4F\u2D50\u2D51\u2D52\u2D53\u2D54\u2D55\u2D56\u2D57\u2D58\u2D59\u2D5A\u2D5B\u2D5C\u2D5D\u2D5E\u2D5F\u2D60\u2D61\u2D62\u2D63\u2D64\u2D65\u2D80\u2D81\u2D82\u2D83\u2D84\u2D85\u2D86\u2D87\u2D88\u2D89\u2D8A\u2D8B\u2D8C\u2D8D\u2D8E\u2D8F\u2D90\u2D91\u2D92\u2D93\u2D94\u2D95\u2D96\u2DA0\u2DA1\u2DA2\u2DA3\u2DA4\u2DA5\u2DA6\u2DA8\u2DA9\u2DAA\u2DAB\u2DAC\u2DAD\u2DAE\u2DB0\u2DB1\u2DB2\u2DB3\u2DB4\u2DB5\u2DB6\u2DB8\u2DB9\u2DBA\u2DBB\u2DBC\u2DBD\u2DBE\u2DC0\u2DC1\u2DC2\u2DC3\u2DC4\u2DC5\u2DC6\u2DC8\u2DC9\u2DCA\u2DCB\u2DCC\u2DCD\u2DCE\u2DD0\u2DD1\u2DD2\u2DD3\u2DD4\u2DD5\u2DD6\u2DD8\u2DD9\u2DDA\u2DDB\u2DDC\u2DDD\u2DDE\u3006\u303C\u3041\u3042\u3043\u3044\u3045\u3046\u3047\u3048\u3049\u304A\u304B\u304C\u304D\u304E\u304F\u3050\u3051\u3052\u3053\u3054\u3055\u3056\u3057\u3058\u3059\u305A\u305B\u305C\u305D\u305E\u305F\u3060\u3061\u3062\u3063\u3064\u3065\u3066\u3067\u3068\u3069\u306A\u306B\u306C\u306D\u306E\u306F\u3070\u3071\u3072\u3073\u3074\u3075\u3076\u3077\u3078\u3079\u307A\u307B\u307C\u307D\u307E\u307F\u3080\u3081\u3082\u3083\u3084\u3085\u3086\u3087\u3088\u3089\u308A\u308B\u308C\u308D\u308E\u308F\u3090\u3091\u3092\u3093\u3094\u3095\u3096\u309F\u30A1\u30A2\u30A3\u30A4\u30A5\u30A6\u30A7\u30A8\u30A9\u30AA\u30AB\u30AC\u30AD\u30AE\u30AF\u30B0\u30B1\u30B2\u30B3\u30B4\u30B5\u30B6\u30B7\u30B8\u30B9\u30BA\u30BB\u30BC\u30BD\u30BE\u30BF\u30C0\u30C1\u30C2\u30C3\u30C4\u30C5\u30C6\u30C7\u30C8\u30C9\u30CA\u30CB\u30CC\u30CD\u30CE\u30CF\u30D0\u30D1\u30D2\u30D3\u30D4\u30D5\u30D6\u30D7\u30D8\u30D9\u30DA\u30DB\u30DC\u30DD\u30DE\u30DF\u30E0\u30E1\u30E2\u30E3\u30E4\u30E5\u30E6\u30E7\u30E8\u30E9\u30EA\u30EB\u30EC\u30ED\u30EE\u30EF\u30F0\u30F1\u30F2\u30F3\u30F4\u30F5\u30F6\u30F7\u30F8\u30F9\u30FA\u30FF\u3105\u3106\u3107\u3108\u3109\u310A\u310B\u310C\u310D\u310E\u310F\u3110\u3111\u3112\u3113\u3114\u3115\u3116\u3117\u3118\u3119\u311A\u311B\u311C\u311D\u311E\u311F\u3120\u3121\u3122\u3123\u3124\u3125\u3126\u3127\u3128\u3129\u312A\u312B\u312C\u312D\u3131\u3132\u3133\u3134\u3135\u3136\u3137\u3138\u3139\u313A\u313B\u313C\u313D\u313E\u313F\u3140\u3141\u3142\u3143\u3144\u3145\u3146\u3147\u3148\u3149\u314A\u314B\u314C\u314D\u314E\u314F\u3150\u3151\u3152\u3153\u3154\u3155\u3156\u3157\u3158\u3159\u315A\u315B\u315C\u315D\u315E\u315F\u3160\u3161\u3162\u3163\u3164\u3165\u3166\u3167\u3168\u3169\u316A\u316B\u316C\u316D\u316E\u316F\u3170\u3171\u3172\u3173\u3174\u3175\u3176\u3177\u3178\u3179\u317A\u317B\u317C\u317D\u317E\u317F\u3180\u3181\u3182\u3183\u3184\u3185\u3186\u3187\u3188\u3189\u318A\u318B\u318C\u318D\u318E\u31A0\u31A1\u31A2\u31A3\u31A4\u31A5\u31A6\u31A7\u31A8\u31A9\u31AA\u31AB\u31AC\u31AD\u31AE\u31AF\u31B0\u31B1\u31B2\u31B3\u31B4\u31B5\u31B6\u31B7\u31F0\u31F1\u31F2\u31F3\u31F4\u31F5\u31F6\u31F7\u31F8\u31F9\u31FA\u31FB\u31FC\u31FD\u31FE\u31FF\u3400\u4DB5\u4E00\u9FC3\uA000\uA001\uA002\uA003\uA004\uA005\uA006\uA007\uA008\uA009\uA00A\uA00B\uA00C\uA00D\uA00E\uA00F\uA010\uA011\uA012\uA013\uA014\uA016\uA017\uA018\uA019\uA01A\uA01B\uA01C\uA01D\uA01E\uA01F\uA020\uA021\uA022\uA023\uA024\uA025\uA026\uA027\uA028\uA029\uA02A\uA02B\uA02C\uA02D\uA02E\uA02F\uA030\uA031\uA032\uA033\uA034\uA035\uA036\uA037\uA038\uA039\uA03A\uA03B\uA03C\uA03D\uA03E\uA03F\uA040\uA041\uA042\uA043\uA044\uA045\uA046\uA047\uA048\uA049\uA04A\uA04B\uA04C\uA04D\uA04E\uA04F\uA050\uA051\uA052\uA053\uA054\uA055\uA056\uA057\uA058\uA059\uA05A\uA05B\uA05C\uA05D\uA05E\uA05F\uA060\uA061\uA062\uA063\uA064\uA065\uA066\uA067\uA068\uA069\uA06A\uA06B\uA06C\uA06D\uA06E\uA06F\uA070\uA071\uA072\uA073\uA074\uA075\uA076\uA077\uA078\uA079\uA07A\uA07B\uA07C\uA07D\uA07E\uA07F\uA080\uA081\uA082\uA083\uA084\uA085\uA086\uA087\uA088\uA089\uA08A\uA08B\uA08C\uA08D\uA08E\uA08F\uA090\uA091\uA092\uA093\uA094\uA095\uA096\uA097\uA098\uA099\uA09A\uA09B\uA09C\uA09D\uA09E\uA09F\uA0A0\uA0A1\uA0A2\uA0A3\uA0A4\uA0A5\uA0A6\uA0A7\uA0A8\uA0A9\uA0AA\uA0AB\uA0AC\uA0AD\uA0AE\uA0AF\uA0B0\uA0B1\uA0B2\uA0B3\uA0B4\uA0B5\uA0B6\uA0B7\uA0B8\uA0B9\uA0BA\uA0BB\uA0BC\uA0BD\uA0BE\uA0BF\uA0C0\uA0C1\uA0C2\uA0C3\uA0C4\uA0C5\uA0C6\uA0C7\uA0C8\uA0C9\uA0CA\uA0CB\uA0CC\uA0CD\uA0CE\uA0CF\uA0D0\uA0D1\uA0D2\uA0D3\uA0D4\uA0D5\uA0D6\uA0D7\uA0D8\uA0D9\uA0DA\uA0DB\uA0DC\uA0DD\uA0DE\uA0DF\uA0E0\uA0E1\uA0E2\uA0E3\uA0E4\uA0E5\uA0E6\uA0E7\uA0E8\uA0E9\uA0EA\uA0EB\uA0EC\uA0ED\uA0EE\uA0EF\uA0F0\uA0F1\uA0F2\uA0F3\uA0F4\uA0F5\uA0F6\uA0F7\uA0F8\uA0F9\uA0FA\uA0FB\uA0FC\uA0FD\uA0FE\uA0FF\uA100\uA101\uA102\uA103\uA104\uA105\uA106\uA107\uA108\uA109\uA10A\uA10B\uA10C\uA10D\uA10E\uA10F\uA110\uA111\uA112\uA113\uA114\uA115\uA116\uA117\uA118\uA119\uA11A\uA11B\uA11C\uA11D\uA11E\uA11F\uA120\uA121\uA122\uA123\uA124\uA125\uA126\uA127\uA128\uA129\uA12A\uA12B\uA12C\uA12D\uA12E\uA12F\uA130\uA131\uA132\uA133\uA134\uA135\uA136\uA137\uA138\uA139\uA13A\uA13B\uA13C\uA13D\uA13E\uA13F\uA140\uA141\uA142\uA143\uA144\uA145\uA146\uA147\uA148\uA149\uA14A\uA14B\uA14C\uA14D\uA14E\uA14F\uA150\uA151\uA152\uA153\uA154\uA155\uA156\uA157\uA158\uA159\uA15A\uA15B\uA15C\uA15D\uA15E\uA15F\uA160\uA161\uA162\uA163\uA164\uA165\uA166\uA167\uA168\uA169\uA16A\uA16B\uA16C\uA16D\uA16E\uA16F\uA170\uA171\uA172\uA173\uA174\uA175\uA176\uA177\uA178\uA179\uA17A\uA17B\uA17C\uA17D\uA17E\uA17F\uA180\uA181\uA182\uA183\uA184\uA185\uA186\uA187\uA188\uA189\uA18A\uA18B\uA18C\uA18D\uA18E\uA18F\uA190\uA191\uA192\uA193\uA194\uA195\uA196\uA197\uA198\uA199\uA19A\uA19B\uA19C\uA19D\uA19E\uA19F\uA1A0\uA1A1\uA1A2\uA1A3\uA1A4\uA1A5\uA1A6\uA1A7\uA1A8\uA1A9\uA1AA\uA1AB\uA1AC\uA1AD\uA1AE\uA1AF]/,
-      peg$c256 = peg$classExpectation(["\u01BB", "\u01C0", "\u01C1", "\u01C2", "\u01C3", "\u0294", "\u05D0", "\u05D1", "\u05D2", "\u05D3", "\u05D4", "\u05D5", "\u05D6", "\u05D7", "\u05D8", "\u05D9", "\u05DA", "\u05DB", "\u05DC", "\u05DD", "\u05DE", "\u05DF", "\u05E0", "\u05E1", "\u05E2", "\u05E3", "\u05E4", "\u05E5", "\u05E6", "\u05E7", "\u05E8", "\u05E9", "\u05EA", "\u05F0", "\u05F1", "\u05F2", "\u0621", "\u0622", "\u0623", "\u0624", "\u0625", "\u0626", "\u0627", "\u0628", "\u0629", "\u062A", "\u062B", "\u062C", "\u062D", "\u062E", "\u062F", "\u0630", "\u0631", "\u0632", "\u0633", "\u0634", "\u0635", "\u0636", "\u0637", "\u0638", "\u0639", "\u063A", "\u063B", "\u063C", "\u063D", "\u063E", "\u063F", "\u0641", "\u0642", "\u0643", "\u0644", "\u0645", "\u0646", "\u0647", "\u0648", "\u0649", "\u064A", "\u066E", "\u066F", "\u0671", "\u0672", "\u0673", "\u0674", "\u0675", "\u0676", "\u0677", "\u0678", "\u0679", "\u067A", "\u067B", "\u067C", "\u067D", "\u067E", "\u067F", "\u0680", "\u0681", "\u0682", "\u0683", "\u0684", "\u0685", "\u0686", "\u0687", "\u0688", "\u0689", "\u068A", "\u068B", "\u068C", "\u068D", "\u068E", "\u068F", "\u0690", "\u0691", "\u0692", "\u0693", "\u0694", "\u0695", "\u0696", "\u0697", "\u0698", "\u0699", "\u069A", "\u069B", "\u069C", "\u069D", "\u069E", "\u069F", "\u06A0", "\u06A1", "\u06A2", "\u06A3", "\u06A4", "\u06A5", "\u06A6", "\u06A7", "\u06A8", "\u06A9", "\u06AA", "\u06AB", "\u06AC", "\u06AD", "\u06AE", "\u06AF", "\u06B0", "\u06B1", "\u06B2", "\u06B3", "\u06B4", "\u06B5", "\u06B6", "\u06B7", "\u06B8", "\u06B9", "\u06BA", "\u06BB", "\u06BC", "\u06BD", "\u06BE", "\u06BF", "\u06C0", "\u06C1", "\u06C2", "\u06C3", "\u06C4", "\u06C5", "\u06C6", "\u06C7", "\u06C8", "\u06C9", "\u06CA", "\u06CB", "\u06CC", "\u06CD", "\u06CE", "\u06CF", "\u06D0", "\u06D1", "\u06D2", "\u06D3", "\u06D5", "\u06EE", "\u06EF", "\u06FA", "\u06FB", "\u06FC", "\u06FF", "\u0710", "\u0712", "\u0713", "\u0714", "\u0715", "\u0716", "\u0717", "\u0718", "\u0719", "\u071A", "\u071B", "\u071C", "\u071D", "\u071E", "\u071F", "\u0720", "\u0721", "\u0722", "\u0723", "\u0724", "\u0725", "\u0726", "\u0727", "\u0728", "\u0729", "\u072A", "\u072B", "\u072C", "\u072D", "\u072E", "\u072F", "\u074D", "\u074E", "\u074F", "\u0750", "\u0751", "\u0752", "\u0753", "\u0754", "\u0755", "\u0756", "\u0757", "\u0758", "\u0759", "\u075A", "\u075B", "\u075C", "\u075D", "\u075E", "\u075F", "\u0760", "\u0761", "\u0762", "\u0763", "\u0764", "\u0765", "\u0766", "\u0767", "\u0768", "\u0769", "\u076A", "\u076B", "\u076C", "\u076D", "\u076E", "\u076F", "\u0770", "\u0771", "\u0772", "\u0773", "\u0774", "\u0775", "\u0776", "\u0777", "\u0778", "\u0779", "\u077A", "\u077B", "\u077C", "\u077D", "\u077E", "\u077F", "\u0780", "\u0781", "\u0782", "\u0783", "\u0784", "\u0785", "\u0786", "\u0787", "\u0788", "\u0789", "\u078A", "\u078B", "\u078C", "\u078D", "\u078E", "\u078F", "\u0790", "\u0791", "\u0792", "\u0793", "\u0794", "\u0795", "\u0796", "\u0797", "\u0798", "\u0799", "\u079A", "\u079B", "\u079C", "\u079D", "\u079E", "\u079F", "\u07A0", "\u07A1", "\u07A2", "\u07A3", "\u07A4", "\u07A5", "\u07B1", "\u07CA", "\u07CB", "\u07CC", "\u07CD", "\u07CE", "\u07CF", "\u07D0", "\u07D1", "\u07D2", "\u07D3", "\u07D4", "\u07D5", "\u07D6", "\u07D7", "\u07D8", "\u07D9", "\u07DA", "\u07DB", "\u07DC", "\u07DD", "\u07DE", "\u07DF", "\u07E0", "\u07E1", "\u07E2", "\u07E3", "\u07E4", "\u07E5", "\u07E6", "\u07E7", "\u07E8", "\u07E9", "\u07EA", "\u0904", "\u0905", "\u0906", "\u0907", "\u0908", "\u0909", "\u090A", "\u090B", "\u090C", "\u090D", "\u090E", "\u090F", "\u0910", "\u0911", "\u0912", "\u0913", "\u0914", "\u0915", "\u0916", "\u0917", "\u0918", "\u0919", "\u091A", "\u091B", "\u091C", "\u091D", "\u091E", "\u091F", "\u0920", "\u0921", "\u0922", "\u0923", "\u0924", "\u0925", "\u0926", "\u0927", "\u0928", "\u0929", "\u092A", "\u092B", "\u092C", "\u092D", "\u092E", "\u092F", "\u0930", "\u0931", "\u0932", "\u0933", "\u0934", "\u0935", "\u0936", "\u0937", "\u0938", "\u0939", "\u093D", "\u0950", "\u0958", "\u0959", "\u095A", "\u095B", "\u095C", "\u095D", "\u095E", "\u095F", "\u0960", "\u0961", "\u0972", "\u097B", "\u097C", "\u097D", "\u097E", "\u097F", "\u0985", "\u0986", "\u0987", "\u0988", "\u0989", "\u098A", "\u098B", "\u098C", "\u098F", "\u0990", "\u0993", "\u0994", "\u0995", "\u0996", "\u0997", "\u0998", "\u0999", "\u099A", "\u099B", "\u099C", "\u099D", "\u099E", "\u099F", "\u09A0", "\u09A1", "\u09A2", "\u09A3", "\u09A4", "\u09A5", "\u09A6", "\u09A7", "\u09A8", "\u09AA", "\u09AB", "\u09AC", "\u09AD", "\u09AE", "\u09AF", "\u09B0", "\u09B2", "\u09B6", "\u09B7", "\u09B8", "\u09B9", "\u09BD", "\u09CE", "\u09DC", "\u09DD", "\u09DF", "\u09E0", "\u09E1", "\u09F0", "\u09F1", "\u0A05", "\u0A06", "\u0A07", "\u0A08", "\u0A09", "\u0A0A", "\u0A0F", "\u0A10", "\u0A13", "\u0A14", "\u0A15", "\u0A16", "\u0A17", "\u0A18", "\u0A19", "\u0A1A", "\u0A1B", "\u0A1C", "\u0A1D", "\u0A1E", "\u0A1F", "\u0A20", "\u0A21", "\u0A22", "\u0A23", "\u0A24", "\u0A25", "\u0A26", "\u0A27", "\u0A28", "\u0A2A", "\u0A2B", "\u0A2C", "\u0A2D", "\u0A2E", "\u0A2F", "\u0A30", "\u0A32", "\u0A33", "\u0A35", "\u0A36", "\u0A38", "\u0A39", "\u0A59", "\u0A5A", "\u0A5B", "\u0A5C", "\u0A5E", "\u0A72", "\u0A73", "\u0A74", "\u0A85", "\u0A86", "\u0A87", "\u0A88", "\u0A89", "\u0A8A", "\u0A8B", "\u0A8C", "\u0A8D", "\u0A8F", "\u0A90", "\u0A91", "\u0A93", "\u0A94", "\u0A95", "\u0A96", "\u0A97", "\u0A98", "\u0A99", "\u0A9A", "\u0A9B", "\u0A9C", "\u0A9D", "\u0A9E", "\u0A9F", "\u0AA0", "\u0AA1", "\u0AA2", "\u0AA3", "\u0AA4", "\u0AA5", "\u0AA6", "\u0AA7", "\u0AA8", "\u0AAA", "\u0AAB", "\u0AAC", "\u0AAD", "\u0AAE", "\u0AAF", "\u0AB0", "\u0AB2", "\u0AB3", "\u0AB5", "\u0AB6", "\u0AB7", "\u0AB8", "\u0AB9", "\u0ABD", "\u0AD0", "\u0AE0", "\u0AE1", "\u0B05", "\u0B06", "\u0B07", "\u0B08", "\u0B09", "\u0B0A", "\u0B0B", "\u0B0C", "\u0B0F", "\u0B10", "\u0B13", "\u0B14", "\u0B15", "\u0B16", "\u0B17", "\u0B18", "\u0B19", "\u0B1A", "\u0B1B", "\u0B1C", "\u0B1D", "\u0B1E", "\u0B1F", "\u0B20", "\u0B21", "\u0B22", "\u0B23", "\u0B24", "\u0B25", "\u0B26", "\u0B27", "\u0B28", "\u0B2A", "\u0B2B", "\u0B2C", "\u0B2D", "\u0B2E", "\u0B2F", "\u0B30", "\u0B32", "\u0B33", "\u0B35", "\u0B36", "\u0B37", "\u0B38", "\u0B39", "\u0B3D", "\u0B5C", "\u0B5D", "\u0B5F", "\u0B60", "\u0B61", "\u0B71", "\u0B83", "\u0B85", "\u0B86", "\u0B87", "\u0B88", "\u0B89", "\u0B8A", "\u0B8E", "\u0B8F", "\u0B90", "\u0B92", "\u0B93", "\u0B94", "\u0B95", "\u0B99", "\u0B9A", "\u0B9C", "\u0B9E", "\u0B9F", "\u0BA3", "\u0BA4", "\u0BA8", "\u0BA9", "\u0BAA", "\u0BAE", "\u0BAF", "\u0BB0", "\u0BB1", "\u0BB2", "\u0BB3", "\u0BB4", "\u0BB5", "\u0BB6", "\u0BB7", "\u0BB8", "\u0BB9", "\u0BD0", "\u0C05", "\u0C06", "\u0C07", "\u0C08", "\u0C09", "\u0C0A", "\u0C0B", "\u0C0C", "\u0C0E", "\u0C0F", "\u0C10", "\u0C12", "\u0C13", "\u0C14", "\u0C15", "\u0C16", "\u0C17", "\u0C18", "\u0C19", "\u0C1A", "\u0C1B", "\u0C1C", "\u0C1D", "\u0C1E", "\u0C1F", "\u0C20", "\u0C21", "\u0C22", "\u0C23", "\u0C24", "\u0C25", "\u0C26", "\u0C27", "\u0C28", "\u0C2A", "\u0C2B", "\u0C2C", "\u0C2D", "\u0C2E", "\u0C2F", "\u0C30", "\u0C31", "\u0C32", "\u0C33", "\u0C35", "\u0C36", "\u0C37", "\u0C38", "\u0C39", "\u0C3D", "\u0C58", "\u0C59", "\u0C60", "\u0C61", "\u0C85", "\u0C86", "\u0C87", "\u0C88", "\u0C89", "\u0C8A", "\u0C8B", "\u0C8C", "\u0C8E", "\u0C8F", "\u0C90", "\u0C92", "\u0C93", "\u0C94", "\u0C95", "\u0C96", "\u0C97", "\u0C98", "\u0C99", "\u0C9A", "\u0C9B", "\u0C9C", "\u0C9D", "\u0C9E", "\u0C9F", "\u0CA0", "\u0CA1", "\u0CA2", "\u0CA3", "\u0CA4", "\u0CA5", "\u0CA6", "\u0CA7", "\u0CA8", "\u0CAA", "\u0CAB", "\u0CAC", "\u0CAD", "\u0CAE", "\u0CAF", "\u0CB0", "\u0CB1", "\u0CB2", "\u0CB3", "\u0CB5", "\u0CB6", "\u0CB7", "\u0CB8", "\u0CB9", "\u0CBD", "\u0CDE", "\u0CE0", "\u0CE1", "\u0D05", "\u0D06", "\u0D07", "\u0D08", "\u0D09", "\u0D0A", "\u0D0B", "\u0D0C", "\u0D0E", "\u0D0F", "\u0D10", "\u0D12", "\u0D13", "\u0D14", "\u0D15", "\u0D16", "\u0D17", "\u0D18", "\u0D19", "\u0D1A", "\u0D1B", "\u0D1C", "\u0D1D", "\u0D1E", "\u0D1F", "\u0D20", "\u0D21", "\u0D22", "\u0D23", "\u0D24", "\u0D25", "\u0D26", "\u0D27", "\u0D28", "\u0D2A", "\u0D2B", "\u0D2C", "\u0D2D", "\u0D2E", "\u0D2F", "\u0D30", "\u0D31", "\u0D32", "\u0D33", "\u0D34", "\u0D35", "\u0D36", "\u0D37", "\u0D38", "\u0D39", "\u0D3D", "\u0D60", "\u0D61", "\u0D7A", "\u0D7B", "\u0D7C", "\u0D7D", "\u0D7E", "\u0D7F", "\u0D85", "\u0D86", "\u0D87", "\u0D88", "\u0D89", "\u0D8A", "\u0D8B", "\u0D8C", "\u0D8D", "\u0D8E", "\u0D8F", "\u0D90", "\u0D91", "\u0D92", "\u0D93", "\u0D94", "\u0D95", "\u0D96", "\u0D9A", "\u0D9B", "\u0D9C", "\u0D9D", "\u0D9E", "\u0D9F", "\u0DA0", "\u0DA1", "\u0DA2", "\u0DA3", "\u0DA4", "\u0DA5", "\u0DA6", "\u0DA7", "\u0DA8", "\u0DA9", "\u0DAA", "\u0DAB", "\u0DAC", "\u0DAD", "\u0DAE", "\u0DAF", "\u0DB0", "\u0DB1", "\u0DB3", "\u0DB4", "\u0DB5", "\u0DB6", "\u0DB7", "\u0DB8", "\u0DB9", "\u0DBA", "\u0DBB", "\u0DBD", "\u0DC0", "\u0DC1", "\u0DC2", "\u0DC3", "\u0DC4", "\u0DC5", "\u0DC6", "\u0E01", "\u0E02", "\u0E03", "\u0E04", "\u0E05", "\u0E06", "\u0E07", "\u0E08", "\u0E09", "\u0E0A", "\u0E0B", "\u0E0C", "\u0E0D", "\u0E0E", "\u0E0F", "\u0E10", "\u0E11", "\u0E12", "\u0E13", "\u0E14", "\u0E15", "\u0E16", "\u0E17", "\u0E18", "\u0E19", "\u0E1A", "\u0E1B", "\u0E1C", "\u0E1D", "\u0E1E", "\u0E1F", "\u0E20", "\u0E21", "\u0E22", "\u0E23", "\u0E24", "\u0E25", "\u0E26", "\u0E27", "\u0E28", "\u0E29", "\u0E2A", "\u0E2B", "\u0E2C", "\u0E2D", "\u0E2E", "\u0E2F", "\u0E30", "\u0E32", "\u0E33", "\u0E40", "\u0E41", "\u0E42", "\u0E43", "\u0E44", "\u0E45", "\u0E81", "\u0E82", "\u0E84", "\u0E87", "\u0E88", "\u0E8A", "\u0E8D", "\u0E94", "\u0E95", "\u0E96", "\u0E97", "\u0E99", "\u0E9A", "\u0E9B", "\u0E9C", "\u0E9D", "\u0E9E", "\u0E9F", "\u0EA1", "\u0EA2", "\u0EA3", "\u0EA5", "\u0EA7", "\u0EAA", "\u0EAB", "\u0EAD", "\u0EAE", "\u0EAF", "\u0EB0", "\u0EB2", "\u0EB3", "\u0EBD", "\u0EC0", "\u0EC1", "\u0EC2", "\u0EC3", "\u0EC4", "\u0EDC", "\u0EDD", "\u0F00", "\u0F40", "\u0F41", "\u0F42", "\u0F43", "\u0F44", "\u0F45", "\u0F46", "\u0F47", "\u0F49", "\u0F4A", "\u0F4B", "\u0F4C", "\u0F4D", "\u0F4E", "\u0F4F", "\u0F50", "\u0F51", "\u0F52", "\u0F53", "\u0F54", "\u0F55", "\u0F56", "\u0F57", "\u0F58", "\u0F59", "\u0F5A", "\u0F5B", "\u0F5C", "\u0F5D", "\u0F5E", "\u0F5F", "\u0F60", "\u0F61", "\u0F62", "\u0F63", "\u0F64", "\u0F65", "\u0F66", "\u0F67", "\u0F68", "\u0F69", "\u0F6A", "\u0F6B", "\u0F6C", "\u0F88", "\u0F89", "\u0F8A", "\u0F8B", "\u1000", "\u1001", "\u1002", "\u1003", "\u1004", "\u1005", "\u1006", "\u1007", "\u1008", "\u1009", "\u100A", "\u100B", "\u100C", "\u100D", "\u100E", "\u100F", "\u1010", "\u1011", "\u1012", "\u1013", "\u1014", "\u1015", "\u1016", "\u1017", "\u1018", "\u1019", "\u101A", "\u101B", "\u101C", "\u101D", "\u101E", "\u101F", "\u1020", "\u1021", "\u1022", "\u1023", "\u1024", "\u1025", "\u1026", "\u1027", "\u1028", "\u1029", "\u102A", "\u103F", "\u1050", "\u1051", "\u1052", "\u1053", "\u1054", "\u1055", "\u105A", "\u105B", "\u105C", "\u105D", "\u1061", "\u1065", "\u1066", "\u106E", "\u106F", "\u1070", "\u1075", "\u1076", "\u1077", "\u1078", "\u1079", "\u107A", "\u107B", "\u107C", "\u107D", "\u107E", "\u107F", "\u1080", "\u1081", "\u108E", "\u10D0", "\u10D1", "\u10D2", "\u10D3", "\u10D4", "\u10D5", "\u10D6", "\u10D7", "\u10D8", "\u10D9", "\u10DA", "\u10DB", "\u10DC", "\u10DD", "\u10DE", "\u10DF", "\u10E0", "\u10E1", "\u10E2", "\u10E3", "\u10E4", "\u10E5", "\u10E6", "\u10E7", "\u10E8", "\u10E9", "\u10EA", "\u10EB", "\u10EC", "\u10ED", "\u10EE", "\u10EF", "\u10F0", "\u10F1", "\u10F2", "\u10F3", "\u10F4", "\u10F5", "\u10F6", "\u10F7", "\u10F8", "\u10F9", "\u10FA", "\u1100", "\u1101", "\u1102", "\u1103", "\u1104", "\u1105", "\u1106", "\u1107", "\u1108", "\u1109", "\u110A", "\u110B", "\u110C", "\u110D", "\u110E", "\u110F", "\u1110", "\u1111", "\u1112", "\u1113", "\u1114", "\u1115", "\u1116", "\u1117", "\u1118", "\u1119", "\u111A", "\u111B", "\u111C", "\u111D", "\u111E", "\u111F", "\u1120", "\u1121", "\u1122", "\u1123", "\u1124", "\u1125", "\u1126", "\u1127", "\u1128", "\u1129", "\u112A", "\u112B", "\u112C", "\u112D", "\u112E", "\u112F", "\u1130", "\u1131", "\u1132", "\u1133", "\u1134", "\u1135", "\u1136", "\u1137", "\u1138", "\u1139", "\u113A", "\u113B", "\u113C", "\u113D", "\u113E", "\u113F", "\u1140", "\u1141", "\u1142", "\u1143", "\u1144", "\u1145", "\u1146", "\u1147", "\u1148", "\u1149", "\u114A", "\u114B", "\u114C", "\u114D", "\u114E", "\u114F", "\u1150", "\u1151", "\u1152", "\u1153", "\u1154", "\u1155", "\u1156", "\u1157", "\u1158", "\u1159", "\u115F", "\u1160", "\u1161", "\u1162", "\u1163", "\u1164", "\u1165", "\u1166", "\u1167", "\u1168", "\u1169", "\u116A", "\u116B", "\u116C", "\u116D", "\u116E", "\u116F", "\u1170", "\u1171", "\u1172", "\u1173", "\u1174", "\u1175", "\u1176", "\u1177", "\u1178", "\u1179", "\u117A", "\u117B", "\u117C", "\u117D", "\u117E", "\u117F", "\u1180", "\u1181", "\u1182", "\u1183", "\u1184", "\u1185", "\u1186", "\u1187", "\u1188", "\u1189", "\u118A", "\u118B", "\u118C", "\u118D", "\u118E", "\u118F", "\u1190", "\u1191", "\u1192", "\u1193", "\u1194", "\u1195", "\u1196", "\u1197", "\u1198", "\u1199", "\u119A", "\u119B", "\u119C", "\u119D", "\u119E", "\u119F", "\u11A0", "\u11A1", "\u11A2", "\u11A8", "\u11A9", "\u11AA", "\u11AB", "\u11AC", "\u11AD", "\u11AE", "\u11AF", "\u11B0", "\u11B1", "\u11B2", "\u11B3", "\u11B4", "\u11B5", "\u11B6", "\u11B7", "\u11B8", "\u11B9", "\u11BA", "\u11BB", "\u11BC", "\u11BD", "\u11BE", "\u11BF", "\u11C0", "\u11C1", "\u11C2", "\u11C3", "\u11C4", "\u11C5", "\u11C6", "\u11C7", "\u11C8", "\u11C9", "\u11CA", "\u11CB", "\u11CC", "\u11CD", "\u11CE", "\u11CF", "\u11D0", "\u11D1", "\u11D2", "\u11D3", "\u11D4", "\u11D5", "\u11D6", "\u11D7", "\u11D8", "\u11D9", "\u11DA", "\u11DB", "\u11DC", "\u11DD", "\u11DE", "\u11DF", "\u11E0", "\u11E1", "\u11E2", "\u11E3", "\u11E4", "\u11E5", "\u11E6", "\u11E7", "\u11E8", "\u11E9", "\u11EA", "\u11EB", "\u11EC", "\u11ED", "\u11EE", "\u11EF", "\u11F0", "\u11F1", "\u11F2", "\u11F3", "\u11F4", "\u11F5", "\u11F6", "\u11F7", "\u11F8", "\u11F9", "\u1200", "\u1201", "\u1202", "\u1203", "\u1204", "\u1205", "\u1206", "\u1207", "\u1208", "\u1209", "\u120A", "\u120B", "\u120C", "\u120D", "\u120E", "\u120F", "\u1210", "\u1211", "\u1212", "\u1213", "\u1214", "\u1215", "\u1216", "\u1217", "\u1218", "\u1219", "\u121A", "\u121B", "\u121C", "\u121D", "\u121E", "\u121F", "\u1220", "\u1221", "\u1222", "\u1223", "\u1224", "\u1225", "\u1226", "\u1227", "\u1228", "\u1229", "\u122A", "\u122B", "\u122C", "\u122D", "\u122E", "\u122F", "\u1230", "\u1231", "\u1232", "\u1233", "\u1234", "\u1235", "\u1236", "\u1237", "\u1238", "\u1239", "\u123A", "\u123B", "\u123C", "\u123D", "\u123E", "\u123F", "\u1240", "\u1241", "\u1242", "\u1243", "\u1244", "\u1245", "\u1246", "\u1247", "\u1248", "\u124A", "\u124B", "\u124C", "\u124D", "\u1250", "\u1251", "\u1252", "\u1253", "\u1254", "\u1255", "\u1256", "\u1258", "\u125A", "\u125B", "\u125C", "\u125D", "\u1260", "\u1261", "\u1262", "\u1263", "\u1264", "\u1265", "\u1266", "\u1267", "\u1268", "\u1269", "\u126A", "\u126B", "\u126C", "\u126D", "\u126E", "\u126F", "\u1270", "\u1271", "\u1272", "\u1273", "\u1274", "\u1275", "\u1276", "\u1277", "\u1278", "\u1279", "\u127A", "\u127B", "\u127C", "\u127D", "\u127E", "\u127F", "\u1280", "\u1281", "\u1282", "\u1283", "\u1284", "\u1285", "\u1286", "\u1287", "\u1288", "\u128A", "\u128B", "\u128C", "\u128D", "\u1290", "\u1291", "\u1292", "\u1293", "\u1294", "\u1295", "\u1296", "\u1297", "\u1298", "\u1299", "\u129A", "\u129B", "\u129C", "\u129D", "\u129E", "\u129F", "\u12A0", "\u12A1", "\u12A2", "\u12A3", "\u12A4", "\u12A5", "\u12A6", "\u12A7", "\u12A8", "\u12A9", "\u12AA", "\u12AB", "\u12AC", "\u12AD", "\u12AE", "\u12AF", "\u12B0", "\u12B2", "\u12B3", "\u12B4", "\u12B5", "\u12B8", "\u12B9", "\u12BA", "\u12BB", "\u12BC", "\u12BD", "\u12BE", "\u12C0", "\u12C2", "\u12C3", "\u12C4", "\u12C5", "\u12C8", "\u12C9", "\u12CA", "\u12CB", "\u12CC", "\u12CD", "\u12CE", "\u12CF", "\u12D0", "\u12D1", "\u12D2", "\u12D3", "\u12D4", "\u12D5", "\u12D6", "\u12D8", "\u12D9", "\u12DA", "\u12DB", "\u12DC", "\u12DD", "\u12DE", "\u12DF", "\u12E0", "\u12E1", "\u12E2", "\u12E3", "\u12E4", "\u12E5", "\u12E6", "\u12E7", "\u12E8", "\u12E9", "\u12EA", "\u12EB", "\u12EC", "\u12ED", "\u12EE", "\u12EF", "\u12F0", "\u12F1", "\u12F2", "\u12F3", "\u12F4", "\u12F5", "\u12F6", "\u12F7", "\u12F8", "\u12F9", "\u12FA", "\u12FB", "\u12FC", "\u12FD", "\u12FE", "\u12FF", "\u1300", "\u1301", "\u1302", "\u1303", "\u1304", "\u1305", "\u1306", "\u1307", "\u1308", "\u1309", "\u130A", "\u130B", "\u130C", "\u130D", "\u130E", "\u130F", "\u1310", "\u1312", "\u1313", "\u1314", "\u1315", "\u1318", "\u1319", "\u131A", "\u131B", "\u131C", "\u131D", "\u131E", "\u131F", "\u1320", "\u1321", "\u1322", "\u1323", "\u1324", "\u1325", "\u1326", "\u1327", "\u1328", "\u1329", "\u132A", "\u132B", "\u132C", "\u132D", "\u132E", "\u132F", "\u1330", "\u1331", "\u1332", "\u1333", "\u1334", "\u1335", "\u1336", "\u1337", "\u1338", "\u1339", "\u133A", "\u133B", "\u133C", "\u133D", "\u133E", "\u133F", "\u1340", "\u1341", "\u1342", "\u1343", "\u1344", "\u1345", "\u1346", "\u1347", "\u1348", "\u1349", "\u134A", "\u134B", "\u134C", "\u134D", "\u134E", "\u134F", "\u1350", "\u1351", "\u1352", "\u1353", "\u1354", "\u1355", "\u1356", "\u1357", "\u1358", "\u1359", "\u135A", "\u1380", "\u1381", "\u1382", "\u1383", "\u1384", "\u1385", "\u1386", "\u1387", "\u1388", "\u1389", "\u138A", "\u138B", "\u138C", "\u138D", "\u138E", "\u138F", "\u13A0", "\u13A1", "\u13A2", "\u13A3", "\u13A4", "\u13A5", "\u13A6", "\u13A7", "\u13A8", "\u13A9", "\u13AA", "\u13AB", "\u13AC", "\u13AD", "\u13AE", "\u13AF", "\u13B0", "\u13B1", "\u13B2", "\u13B3", "\u13B4", "\u13B5", "\u13B6", "\u13B7", "\u13B8", "\u13B9", "\u13BA", "\u13BB", "\u13BC", "\u13BD", "\u13BE", "\u13BF", "\u13C0", "\u13C1", "\u13C2", "\u13C3", "\u13C4", "\u13C5", "\u13C6", "\u13C7", "\u13C8", "\u13C9", "\u13CA", "\u13CB", "\u13CC", "\u13CD", "\u13CE", "\u13CF", "\u13D0", "\u13D1", "\u13D2", "\u13D3", "\u13D4", "\u13D5", "\u13D6", "\u13D7", "\u13D8", "\u13D9", "\u13DA", "\u13DB", "\u13DC", "\u13DD", "\u13DE", "\u13DF", "\u13E0", "\u13E1", "\u13E2", "\u13E3", "\u13E4", "\u13E5", "\u13E6", "\u13E7", "\u13E8", "\u13E9", "\u13EA", "\u13EB", "\u13EC", "\u13ED", "\u13EE", "\u13EF", "\u13F0", "\u13F1", "\u13F2", "\u13F3", "\u13F4", "\u1401", "\u1402", "\u1403", "\u1404", "\u1405", "\u1406", "\u1407", "\u1408", "\u1409", "\u140A", "\u140B", "\u140C", "\u140D", "\u140E", "\u140F", "\u1410", "\u1411", "\u1412", "\u1413", "\u1414", "\u1415", "\u1416", "\u1417", "\u1418", "\u1419", "\u141A", "\u141B", "\u141C", "\u141D", "\u141E", "\u141F", "\u1420", "\u1421", "\u1422", "\u1423", "\u1424", "\u1425", "\u1426", "\u1427", "\u1428", "\u1429", "\u142A", "\u142B", "\u142C", "\u142D", "\u142E", "\u142F", "\u1430", "\u1431", "\u1432", "\u1433", "\u1434", "\u1435", "\u1436", "\u1437", "\u1438", "\u1439", "\u143A", "\u143B", "\u143C", "\u143D", "\u143E", "\u143F", "\u1440", "\u1441", "\u1442", "\u1443", "\u1444", "\u1445", "\u1446", "\u1447", "\u1448", "\u1449", "\u144A", "\u144B", "\u144C", "\u144D", "\u144E", "\u144F", "\u1450", "\u1451", "\u1452", "\u1453", "\u1454", "\u1455", "\u1456", "\u1457", "\u1458", "\u1459", "\u145A", "\u145B", "\u145C", "\u145D", "\u145E", "\u145F", "\u1460", "\u1461", "\u1462", "\u1463", "\u1464", "\u1465", "\u1466", "\u1467", "\u1468", "\u1469", "\u146A", "\u146B", "\u146C", "\u146D", "\u146E", "\u146F", "\u1470", "\u1471", "\u1472", "\u1473", "\u1474", "\u1475", "\u1476", "\u1477", "\u1478", "\u1479", "\u147A", "\u147B", "\u147C", "\u147D", "\u147E", "\u147F", "\u1480", "\u1481", "\u1482", "\u1483", "\u1484", "\u1485", "\u1486", "\u1487", "\u1488", "\u1489", "\u148A", "\u148B", "\u148C", "\u148D", "\u148E", "\u148F", "\u1490", "\u1491", "\u1492", "\u1493", "\u1494", "\u1495", "\u1496", "\u1497", "\u1498", "\u1499", "\u149A", "\u149B", "\u149C", "\u149D", "\u149E", "\u149F", "\u14A0", "\u14A1", "\u14A2", "\u14A3", "\u14A4", "\u14A5", "\u14A6", "\u14A7", "\u14A8", "\u14A9", "\u14AA", "\u14AB", "\u14AC", "\u14AD", "\u14AE", "\u14AF", "\u14B0", "\u14B1", "\u14B2", "\u14B3", "\u14B4", "\u14B5", "\u14B6", "\u14B7", "\u14B8", "\u14B9", "\u14BA", "\u14BB", "\u14BC", "\u14BD", "\u14BE", "\u14BF", "\u14C0", "\u14C1", "\u14C2", "\u14C3", "\u14C4", "\u14C5", "\u14C6", "\u14C7", "\u14C8", "\u14C9", "\u14CA", "\u14CB", "\u14CC", "\u14CD", "\u14CE", "\u14CF", "\u14D0", "\u14D1", "\u14D2", "\u14D3", "\u14D4", "\u14D5", "\u14D6", "\u14D7", "\u14D8", "\u14D9", "\u14DA", "\u14DB", "\u14DC", "\u14DD", "\u14DE", "\u14DF", "\u14E0", "\u14E1", "\u14E2", "\u14E3", "\u14E4", "\u14E5", "\u14E6", "\u14E7", "\u14E8", "\u14E9", "\u14EA", "\u14EB", "\u14EC", "\u14ED", "\u14EE", "\u14EF", "\u14F0", "\u14F1", "\u14F2", "\u14F3", "\u14F4", "\u14F5", "\u14F6", "\u14F7", "\u14F8", "\u14F9", "\u14FA", "\u14FB", "\u14FC", "\u14FD", "\u14FE", "\u14FF", "\u1500", "\u1501", "\u1502", "\u1503", "\u1504", "\u1505", "\u1506", "\u1507", "\u1508", "\u1509", "\u150A", "\u150B", "\u150C", "\u150D", "\u150E", "\u150F", "\u1510", "\u1511", "\u1512", "\u1513", "\u1514", "\u1515", "\u1516", "\u1517", "\u1518", "\u1519", "\u151A", "\u151B", "\u151C", "\u151D", "\u151E", "\u151F", "\u1520", "\u1521", "\u1522", "\u1523", "\u1524", "\u1525", "\u1526", "\u1527", "\u1528", "\u1529", "\u152A", "\u152B", "\u152C", "\u152D", "\u152E", "\u152F", "\u1530", "\u1531", "\u1532", "\u1533", "\u1534", "\u1535", "\u1536", "\u1537", "\u1538", "\u1539", "\u153A", "\u153B", "\u153C", "\u153D", "\u153E", "\u153F", "\u1540", "\u1541", "\u1542", "\u1543", "\u1544", "\u1545", "\u1546", "\u1547", "\u1548", "\u1549", "\u154A", "\u154B", "\u154C", "\u154D", "\u154E", "\u154F", "\u1550", "\u1551", "\u1552", "\u1553", "\u1554", "\u1555", "\u1556", "\u1557", "\u1558", "\u1559", "\u155A", "\u155B", "\u155C", "\u155D", "\u155E", "\u155F", "\u1560", "\u1561", "\u1562", "\u1563", "\u1564", "\u1565", "\u1566", "\u1567", "\u1568", "\u1569", "\u156A", "\u156B", "\u156C", "\u156D", "\u156E", "\u156F", "\u1570", "\u1571", "\u1572", "\u1573", "\u1574", "\u1575", "\u1576", "\u1577", "\u1578", "\u1579", "\u157A", "\u157B", "\u157C", "\u157D", "\u157E", "\u157F", "\u1580", "\u1581", "\u1582", "\u1583", "\u1584", "\u1585", "\u1586", "\u1587", "\u1588", "\u1589", "\u158A", "\u158B", "\u158C", "\u158D", "\u158E", "\u158F", "\u1590", "\u1591", "\u1592", "\u1593", "\u1594", "\u1595", "\u1596", "\u1597", "\u1598", "\u1599", "\u159A", "\u159B", "\u159C", "\u159D", "\u159E", "\u159F", "\u15A0", "\u15A1", "\u15A2", "\u15A3", "\u15A4", "\u15A5", "\u15A6", "\u15A7", "\u15A8", "\u15A9", "\u15AA", "\u15AB", "\u15AC", "\u15AD", "\u15AE", "\u15AF", "\u15B0", "\u15B1", "\u15B2", "\u15B3", "\u15B4", "\u15B5", "\u15B6", "\u15B7", "\u15B8", "\u15B9", "\u15BA", "\u15BB", "\u15BC", "\u15BD", "\u15BE", "\u15BF", "\u15C0", "\u15C1", "\u15C2", "\u15C3", "\u15C4", "\u15C5", "\u15C6", "\u15C7", "\u15C8", "\u15C9", "\u15CA", "\u15CB", "\u15CC", "\u15CD", "\u15CE", "\u15CF", "\u15D0", "\u15D1", "\u15D2", "\u15D3", "\u15D4", "\u15D5", "\u15D6", "\u15D7", "\u15D8", "\u15D9", "\u15DA", "\u15DB", "\u15DC", "\u15DD", "\u15DE", "\u15DF", "\u15E0", "\u15E1", "\u15E2", "\u15E3", "\u15E4", "\u15E5", "\u15E6", "\u15E7", "\u15E8", "\u15E9", "\u15EA", "\u15EB", "\u15EC", "\u15ED", "\u15EE", "\u15EF", "\u15F0", "\u15F1", "\u15F2", "\u15F3", "\u15F4", "\u15F5", "\u15F6", "\u15F7", "\u15F8", "\u15F9", "\u15FA", "\u15FB", "\u15FC", "\u15FD", "\u15FE", "\u15FF", "\u1600", "\u1601", "\u1602", "\u1603", "\u1604", "\u1605", "\u1606", "\u1607", "\u1608", "\u1609", "\u160A", "\u160B", "\u160C", "\u160D", "\u160E", "\u160F", "\u1610", "\u1611", "\u1612", "\u1613", "\u1614", "\u1615", "\u1616", "\u1617", "\u1618", "\u1619", "\u161A", "\u161B", "\u161C", "\u161D", "\u161E", "\u161F", "\u1620", "\u1621", "\u1622", "\u1623", "\u1624", "\u1625", "\u1626", "\u1627", "\u1628", "\u1629", "\u162A", "\u162B", "\u162C", "\u162D", "\u162E", "\u162F", "\u1630", "\u1631", "\u1632", "\u1633", "\u1634", "\u1635", "\u1636", "\u1637", "\u1638", "\u1639", "\u163A", "\u163B", "\u163C", "\u163D", "\u163E", "\u163F", "\u1640", "\u1641", "\u1642", "\u1643", "\u1644", "\u1645", "\u1646", "\u1647", "\u1648", "\u1649", "\u164A", "\u164B", "\u164C", "\u164D", "\u164E", "\u164F", "\u1650", "\u1651", "\u1652", "\u1653", "\u1654", "\u1655", "\u1656", "\u1657", "\u1658", "\u1659", "\u165A", "\u165B", "\u165C", "\u165D", "\u165E", "\u165F", "\u1660", "\u1661", "\u1662", "\u1663", "\u1664", "\u1665", "\u1666", "\u1667", "\u1668", "\u1669", "\u166A", "\u166B", "\u166C", "\u166F", "\u1670", "\u1671", "\u1672", "\u1673", "\u1674", "\u1675", "\u1676", "\u1681", "\u1682", "\u1683", "\u1684", "\u1685", "\u1686", "\u1687", "\u1688", "\u1689", "\u168A", "\u168B", "\u168C", "\u168D", "\u168E", "\u168F", "\u1690", "\u1691", "\u1692", "\u1693", "\u1694", "\u1695", "\u1696", "\u1697", "\u1698", "\u1699", "\u169A", "\u16A0", "\u16A1", "\u16A2", "\u16A3", "\u16A4", "\u16A5", "\u16A6", "\u16A7", "\u16A8", "\u16A9", "\u16AA", "\u16AB", "\u16AC", "\u16AD", "\u16AE", "\u16AF", "\u16B0", "\u16B1", "\u16B2", "\u16B3", "\u16B4", "\u16B5", "\u16B6", "\u16B7", "\u16B8", "\u16B9", "\u16BA", "\u16BB", "\u16BC", "\u16BD", "\u16BE", "\u16BF", "\u16C0", "\u16C1", "\u16C2", "\u16C3", "\u16C4", "\u16C5", "\u16C6", "\u16C7", "\u16C8", "\u16C9", "\u16CA", "\u16CB", "\u16CC", "\u16CD", "\u16CE", "\u16CF", "\u16D0", "\u16D1", "\u16D2", "\u16D3", "\u16D4", "\u16D5", "\u16D6", "\u16D7", "\u16D8", "\u16D9", "\u16DA", "\u16DB", "\u16DC", "\u16DD", "\u16DE", "\u16DF", "\u16E0", "\u16E1", "\u16E2", "\u16E3", "\u16E4", "\u16E5", "\u16E6", "\u16E7", "\u16E8", "\u16E9", "\u16EA", "\u1700", "\u1701", "\u1702", "\u1703", "\u1704", "\u1705", "\u1706", "\u1707", "\u1708", "\u1709", "\u170A", "\u170B", "\u170C", "\u170E", "\u170F", "\u1710", "\u1711", "\u1720", "\u1721", "\u1722", "\u1723", "\u1724", "\u1725", "\u1726", "\u1727", "\u1728", "\u1729", "\u172A", "\u172B", "\u172C", "\u172D", "\u172E", "\u172F", "\u1730", "\u1731", "\u1740", "\u1741", "\u1742", "\u1743", "\u1744", "\u1745", "\u1746", "\u1747", "\u1748", "\u1749", "\u174A", "\u174B", "\u174C", "\u174D", "\u174E", "\u174F", "\u1750", "\u1751", "\u1760", "\u1761", "\u1762", "\u1763", "\u1764", "\u1765", "\u1766", "\u1767", "\u1768", "\u1769", "\u176A", "\u176B", "\u176C", "\u176E", "\u176F", "\u1770", "\u1780", "\u1781", "\u1782", "\u1783", "\u1784", "\u1785", "\u1786", "\u1787", "\u1788", "\u1789", "\u178A", "\u178B", "\u178C", "\u178D", "\u178E", "\u178F", "\u1790", "\u1791", "\u1792", "\u1793", "\u1794", "\u1795", "\u1796", "\u1797", "\u1798", "\u1799", "\u179A", "\u179B", "\u179C", "\u179D", "\u179E", "\u179F", "\u17A0", "\u17A1", "\u17A2", "\u17A3", "\u17A4", "\u17A5", "\u17A6", "\u17A7", "\u17A8", "\u17A9", "\u17AA", "\u17AB", "\u17AC", "\u17AD", "\u17AE", "\u17AF", "\u17B0", "\u17B1", "\u17B2", "\u17B3", "\u17DC", "\u1820", "\u1821", "\u1822", "\u1823", "\u1824", "\u1825", "\u1826", "\u1827", "\u1828", "\u1829", "\u182A", "\u182B", "\u182C", "\u182D", "\u182E", "\u182F", "\u1830", "\u1831", "\u1832", "\u1833", "\u1834", "\u1835", "\u1836", "\u1837", "\u1838", "\u1839", "\u183A", "\u183B", "\u183C", "\u183D", "\u183E", "\u183F", "\u1840", "\u1841", "\u1842", "\u1844", "\u1845", "\u1846", "\u1847", "\u1848", "\u1849", "\u184A", "\u184B", "\u184C", "\u184D", "\u184E", "\u184F", "\u1850", "\u1851", "\u1852", "\u1853", "\u1854", "\u1855", "\u1856", "\u1857", "\u1858", "\u1859", "\u185A", "\u185B", "\u185C", "\u185D", "\u185E", "\u185F", "\u1860", "\u1861", "\u1862", "\u1863", "\u1864", "\u1865", "\u1866", "\u1867", "\u1868", "\u1869", "\u186A", "\u186B", "\u186C", "\u186D", "\u186E", "\u186F", "\u1870", "\u1871", "\u1872", "\u1873", "\u1874", "\u1875", "\u1876", "\u1877", "\u1880", "\u1881", "\u1882", "\u1883", "\u1884", "\u1885", "\u1886", "\u1887", "\u1888", "\u1889", "\u188A", "\u188B", "\u188C", "\u188D", "\u188E", "\u188F", "\u1890", "\u1891", "\u1892", "\u1893", "\u1894", "\u1895", "\u1896", "\u1897", "\u1898", "\u1899", "\u189A", "\u189B", "\u189C", "\u189D", "\u189E", "\u189F", "\u18A0", "\u18A1", "\u18A2", "\u18A3", "\u18A4", "\u18A5", "\u18A6", "\u18A7", "\u18A8", "\u18AA", "\u1900", "\u1901", "\u1902", "\u1903", "\u1904", "\u1905", "\u1906", "\u1907", "\u1908", "\u1909", "\u190A", "\u190B", "\u190C", "\u190D", "\u190E", "\u190F", "\u1910", "\u1911", "\u1912", "\u1913", "\u1914", "\u1915", "\u1916", "\u1917", "\u1918", "\u1919", "\u191A", "\u191B", "\u191C", "\u1950", "\u1951", "\u1952", "\u1953", "\u1954", "\u1955", "\u1956", "\u1957", "\u1958", "\u1959", "\u195A", "\u195B", "\u195C", "\u195D", "\u195E", "\u195F", "\u1960", "\u1961", "\u1962", "\u1963", "\u1964", "\u1965", "\u1966", "\u1967", "\u1968", "\u1969", "\u196A", "\u196B", "\u196C", "\u196D", "\u1970", "\u1971", "\u1972", "\u1973", "\u1974", "\u1980", "\u1981", "\u1982", "\u1983", "\u1984", "\u1985", "\u1986", "\u1987", "\u1988", "\u1989", "\u198A", "\u198B", "\u198C", "\u198D", "\u198E", "\u198F", "\u1990", "\u1991", "\u1992", "\u1993", "\u1994", "\u1995", "\u1996", "\u1997", "\u1998", "\u1999", "\u199A", "\u199B", "\u199C", "\u199D", "\u199E", "\u199F", "\u19A0", "\u19A1", "\u19A2", "\u19A3", "\u19A4", "\u19A5", "\u19A6", "\u19A7", "\u19A8", "\u19A9", "\u19C1", "\u19C2", "\u19C3", "\u19C4", "\u19C5", "\u19C6", "\u19C7", "\u1A00", "\u1A01", "\u1A02", "\u1A03", "\u1A04", "\u1A05", "\u1A06", "\u1A07", "\u1A08", "\u1A09", "\u1A0A", "\u1A0B", "\u1A0C", "\u1A0D", "\u1A0E", "\u1A0F", "\u1A10", "\u1A11", "\u1A12", "\u1A13", "\u1A14", "\u1A15", "\u1A16", "\u1B05", "\u1B06", "\u1B07", "\u1B08", "\u1B09", "\u1B0A", "\u1B0B", "\u1B0C", "\u1B0D", "\u1B0E", "\u1B0F", "\u1B10", "\u1B11", "\u1B12", "\u1B13", "\u1B14", "\u1B15", "\u1B16", "\u1B17", "\u1B18", "\u1B19", "\u1B1A", "\u1B1B", "\u1B1C", "\u1B1D", "\u1B1E", "\u1B1F", "\u1B20", "\u1B21", "\u1B22", "\u1B23", "\u1B24", "\u1B25", "\u1B26", "\u1B27", "\u1B28", "\u1B29", "\u1B2A", "\u1B2B", "\u1B2C", "\u1B2D", "\u1B2E", "\u1B2F", "\u1B30", "\u1B31", "\u1B32", "\u1B33", "\u1B45", "\u1B46", "\u1B47", "\u1B48", "\u1B49", "\u1B4A", "\u1B4B", "\u1B83", "\u1B84", "\u1B85", "\u1B86", "\u1B87", "\u1B88", "\u1B89", "\u1B8A", "\u1B8B", "\u1B8C", "\u1B8D", "\u1B8E", "\u1B8F", "\u1B90", "\u1B91", "\u1B92", "\u1B93", "\u1B94", "\u1B95", "\u1B96", "\u1B97", "\u1B98", "\u1B99", "\u1B9A", "\u1B9B", "\u1B9C", "\u1B9D", "\u1B9E", "\u1B9F", "\u1BA0", "\u1BAE", "\u1BAF", "\u1C00", "\u1C01", "\u1C02", "\u1C03", "\u1C04", "\u1C05", "\u1C06", "\u1C07", "\u1C08", "\u1C09", "\u1C0A", "\u1C0B", "\u1C0C", "\u1C0D", "\u1C0E", "\u1C0F", "\u1C10", "\u1C11", "\u1C12", "\u1C13", "\u1C14", "\u1C15", "\u1C16", "\u1C17", "\u1C18", "\u1C19", "\u1C1A", "\u1C1B", "\u1C1C", "\u1C1D", "\u1C1E", "\u1C1F", "\u1C20", "\u1C21", "\u1C22", "\u1C23", "\u1C4D", "\u1C4E", "\u1C4F", "\u1C5A", "\u1C5B", "\u1C5C", "\u1C5D", "\u1C5E", "\u1C5F", "\u1C60", "\u1C61", "\u1C62", "\u1C63", "\u1C64", "\u1C65", "\u1C66", "\u1C67", "\u1C68", "\u1C69", "\u1C6A", "\u1C6B", "\u1C6C", "\u1C6D", "\u1C6E", "\u1C6F", "\u1C70", "\u1C71", "\u1C72", "\u1C73", "\u1C74", "\u1C75", "\u1C76", "\u1C77", "\u2135", "\u2136", "\u2137", "\u2138", "\u2D30", "\u2D31", "\u2D32", "\u2D33", "\u2D34", "\u2D35", "\u2D36", "\u2D37", "\u2D38", "\u2D39", "\u2D3A", "\u2D3B", "\u2D3C", "\u2D3D", "\u2D3E", "\u2D3F", "\u2D40", "\u2D41", "\u2D42", "\u2D43", "\u2D44", "\u2D45", "\u2D46", "\u2D47", "\u2D48", "\u2D49", "\u2D4A", "\u2D4B", "\u2D4C", "\u2D4D", "\u2D4E", "\u2D4F", "\u2D50", "\u2D51", "\u2D52", "\u2D53", "\u2D54", "\u2D55", "\u2D56", "\u2D57", "\u2D58", "\u2D59", "\u2D5A", "\u2D5B", "\u2D5C", "\u2D5D", "\u2D5E", "\u2D5F", "\u2D60", "\u2D61", "\u2D62", "\u2D63", "\u2D64", "\u2D65", "\u2D80", "\u2D81", "\u2D82", "\u2D83", "\u2D84", "\u2D85", "\u2D86", "\u2D87", "\u2D88", "\u2D89", "\u2D8A", "\u2D8B", "\u2D8C", "\u2D8D", "\u2D8E", "\u2D8F", "\u2D90", "\u2D91", "\u2D92", "\u2D93", "\u2D94", "\u2D95", "\u2D96", "\u2DA0", "\u2DA1", "\u2DA2", "\u2DA3", "\u2DA4", "\u2DA5", "\u2DA6", "\u2DA8", "\u2DA9", "\u2DAA", "\u2DAB", "\u2DAC", "\u2DAD", "\u2DAE", "\u2DB0", "\u2DB1", "\u2DB2", "\u2DB3", "\u2DB4", "\u2DB5", "\u2DB6", "\u2DB8", "\u2DB9", "\u2DBA", "\u2DBB", "\u2DBC", "\u2DBD", "\u2DBE", "\u2DC0", "\u2DC1", "\u2DC2", "\u2DC3", "\u2DC4", "\u2DC5", "\u2DC6", "\u2DC8", "\u2DC9", "\u2DCA", "\u2DCB", "\u2DCC", "\u2DCD", "\u2DCE", "\u2DD0", "\u2DD1", "\u2DD2", "\u2DD3", "\u2DD4", "\u2DD5", "\u2DD6", "\u2DD8", "\u2DD9", "\u2DDA", "\u2DDB", "\u2DDC", "\u2DDD", "\u2DDE", "\u3006", "\u303C", "\u3041", "\u3042", "\u3043", "\u3044", "\u3045", "\u3046", "\u3047", "\u3048", "\u3049", "\u304A", "\u304B", "\u304C", "\u304D", "\u304E", "\u304F", "\u3050", "\u3051", "\u3052", "\u3053", "\u3054", "\u3055", "\u3056", "\u3057", "\u3058", "\u3059", "\u305A", "\u305B", "\u305C", "\u305D", "\u305E", "\u305F", "\u3060", "\u3061", "\u3062", "\u3063", "\u3064", "\u3065", "\u3066", "\u3067", "\u3068", "\u3069", "\u306A", "\u306B", "\u306C", "\u306D", "\u306E", "\u306F", "\u3070", "\u3071", "\u3072", "\u3073", "\u3074", "\u3075", "\u3076", "\u3077", "\u3078", "\u3079", "\u307A", "\u307B", "\u307C", "\u307D", "\u307E", "\u307F", "\u3080", "\u3081", "\u3082", "\u3083", "\u3084", "\u3085", "\u3086", "\u3087", "\u3088", "\u3089", "\u308A", "\u308B", "\u308C", "\u308D", "\u308E", "\u308F", "\u3090", "\u3091", "\u3092", "\u3093", "\u3094", "\u3095", "\u3096", "\u309F", "\u30A1", "\u30A2", "\u30A3", "\u30A4", "\u30A5", "\u30A6", "\u30A7", "\u30A8", "\u30A9", "\u30AA", "\u30AB", "\u30AC", "\u30AD", "\u30AE", "\u30AF", "\u30B0", "\u30B1", "\u30B2", "\u30B3", "\u30B4", "\u30B5", "\u30B6", "\u30B7", "\u30B8", "\u30B9", "\u30BA", "\u30BB", "\u30BC", "\u30BD", "\u30BE", "\u30BF", "\u30C0", "\u30C1", "\u30C2", "\u30C3", "\u30C4", "\u30C5", "\u30C6", "\u30C7", "\u30C8", "\u30C9", "\u30CA", "\u30CB", "\u30CC", "\u30CD", "\u30CE", "\u30CF", "\u30D0", "\u30D1", "\u30D2", "\u30D3", "\u30D4", "\u30D5", "\u30D6", "\u30D7", "\u30D8", "\u30D9", "\u30DA", "\u30DB", "\u30DC", "\u30DD", "\u30DE", "\u30DF", "\u30E0", "\u30E1", "\u30E2", "\u30E3", "\u30E4", "\u30E5", "\u30E6", "\u30E7", "\u30E8", "\u30E9", "\u30EA", "\u30EB", "\u30EC", "\u30ED", "\u30EE", "\u30EF", "\u30F0", "\u30F1", "\u30F2", "\u30F3", "\u30F4", "\u30F5", "\u30F6", "\u30F7", "\u30F8", "\u30F9", "\u30FA", "\u30FF", "\u3105", "\u3106", "\u3107", "\u3108", "\u3109", "\u310A", "\u310B", "\u310C", "\u310D", "\u310E", "\u310F", "\u3110", "\u3111", "\u3112", "\u3113", "\u3114", "\u3115", "\u3116", "\u3117", "\u3118", "\u3119", "\u311A", "\u311B", "\u311C", "\u311D", "\u311E", "\u311F", "\u3120", "\u3121", "\u3122", "\u3123", "\u3124", "\u3125", "\u3126", "\u3127", "\u3128", "\u3129", "\u312A", "\u312B", "\u312C", "\u312D", "\u3131", "\u3132", "\u3133", "\u3134", "\u3135", "\u3136", "\u3137", "\u3138", "\u3139", "\u313A", "\u313B", "\u313C", "\u313D", "\u313E", "\u313F", "\u3140", "\u3141", "\u3142", "\u3143", "\u3144", "\u3145", "\u3146", "\u3147", "\u3148", "\u3149", "\u314A", "\u314B", "\u314C", "\u314D", "\u314E", "\u314F", "\u3150", "\u3151", "\u3152", "\u3153", "\u3154", "\u3155", "\u3156", "\u3157", "\u3158", "\u3159", "\u315A", "\u315B", "\u315C", "\u315D", "\u315E", "\u315F", "\u3160", "\u3161", "\u3162", "\u3163", "\u3164", "\u3165", "\u3166", "\u3167", "\u3168", "\u3169", "\u316A", "\u316B", "\u316C", "\u316D", "\u316E", "\u316F", "\u3170", "\u3171", "\u3172", "\u3173", "\u3174", "\u3175", "\u3176", "\u3177", "\u3178", "\u3179", "\u317A", "\u317B", "\u317C", "\u317D", "\u317E", "\u317F", "\u3180", "\u3181", "\u3182", "\u3183", "\u3184", "\u3185", "\u3186", "\u3187", "\u3188", "\u3189", "\u318A", "\u318B", "\u318C", "\u318D", "\u318E", "\u31A0", "\u31A1", "\u31A2", "\u31A3", "\u31A4", "\u31A5", "\u31A6", "\u31A7", "\u31A8", "\u31A9", "\u31AA", "\u31AB", "\u31AC", "\u31AD", "\u31AE", "\u31AF", "\u31B0", "\u31B1", "\u31B2", "\u31B3", "\u31B4", "\u31B5", "\u31B6", "\u31B7", "\u31F0", "\u31F1", "\u31F2", "\u31F3", "\u31F4", "\u31F5", "\u31F6", "\u31F7", "\u31F8", "\u31F9", "\u31FA", "\u31FB", "\u31FC", "\u31FD", "\u31FE", "\u31FF", "\u3400", "\u4DB5", "\u4E00", "\u9FC3", "\uA000", "\uA001", "\uA002", "\uA003", "\uA004", "\uA005", "\uA006", "\uA007", "\uA008", "\uA009", "\uA00A", "\uA00B", "\uA00C", "\uA00D", "\uA00E", "\uA00F", "\uA010", "\uA011", "\uA012", "\uA013", "\uA014", "\uA016", "\uA017", "\uA018", "\uA019", "\uA01A", "\uA01B", "\uA01C", "\uA01D", "\uA01E", "\uA01F", "\uA020", "\uA021", "\uA022", "\uA023", "\uA024", "\uA025", "\uA026", "\uA027", "\uA028", "\uA029", "\uA02A", "\uA02B", "\uA02C", "\uA02D", "\uA02E", "\uA02F", "\uA030", "\uA031", "\uA032", "\uA033", "\uA034", "\uA035", "\uA036", "\uA037", "\uA038", "\uA039", "\uA03A", "\uA03B", "\uA03C", "\uA03D", "\uA03E", "\uA03F", "\uA040", "\uA041", "\uA042", "\uA043", "\uA044", "\uA045", "\uA046", "\uA047", "\uA048", "\uA049", "\uA04A", "\uA04B", "\uA04C", "\uA04D", "\uA04E", "\uA04F", "\uA050", "\uA051", "\uA052", "\uA053", "\uA054", "\uA055", "\uA056", "\uA057", "\uA058", "\uA059", "\uA05A", "\uA05B", "\uA05C", "\uA05D", "\uA05E", "\uA05F", "\uA060", "\uA061", "\uA062", "\uA063", "\uA064", "\uA065", "\uA066", "\uA067", "\uA068", "\uA069", "\uA06A", "\uA06B", "\uA06C", "\uA06D", "\uA06E", "\uA06F", "\uA070", "\uA071", "\uA072", "\uA073", "\uA074", "\uA075", "\uA076", "\uA077", "\uA078", "\uA079", "\uA07A", "\uA07B", "\uA07C", "\uA07D", "\uA07E", "\uA07F", "\uA080", "\uA081", "\uA082", "\uA083", "\uA084", "\uA085", "\uA086", "\uA087", "\uA088", "\uA089", "\uA08A", "\uA08B", "\uA08C", "\uA08D", "\uA08E", "\uA08F", "\uA090", "\uA091", "\uA092", "\uA093", "\uA094", "\uA095", "\uA096", "\uA097", "\uA098", "\uA099", "\uA09A", "\uA09B", "\uA09C", "\uA09D", "\uA09E", "\uA09F", "\uA0A0", "\uA0A1", "\uA0A2", "\uA0A3", "\uA0A4", "\uA0A5", "\uA0A6", "\uA0A7", "\uA0A8", "\uA0A9", "\uA0AA", "\uA0AB", "\uA0AC", "\uA0AD", "\uA0AE", "\uA0AF", "\uA0B0", "\uA0B1", "\uA0B2", "\uA0B3", "\uA0B4", "\uA0B5", "\uA0B6", "\uA0B7", "\uA0B8", "\uA0B9", "\uA0BA", "\uA0BB", "\uA0BC", "\uA0BD", "\uA0BE", "\uA0BF", "\uA0C0", "\uA0C1", "\uA0C2", "\uA0C3", "\uA0C4", "\uA0C5", "\uA0C6", "\uA0C7", "\uA0C8", "\uA0C9", "\uA0CA", "\uA0CB", "\uA0CC", "\uA0CD", "\uA0CE", "\uA0CF", "\uA0D0", "\uA0D1", "\uA0D2", "\uA0D3", "\uA0D4", "\uA0D5", "\uA0D6", "\uA0D7", "\uA0D8", "\uA0D9", "\uA0DA", "\uA0DB", "\uA0DC", "\uA0DD", "\uA0DE", "\uA0DF", "\uA0E0", "\uA0E1", "\uA0E2", "\uA0E3", "\uA0E4", "\uA0E5", "\uA0E6", "\uA0E7", "\uA0E8", "\uA0E9", "\uA0EA", "\uA0EB", "\uA0EC", "\uA0ED", "\uA0EE", "\uA0EF", "\uA0F0", "\uA0F1", "\uA0F2", "\uA0F3", "\uA0F4", "\uA0F5", "\uA0F6", "\uA0F7", "\uA0F8", "\uA0F9", "\uA0FA", "\uA0FB", "\uA0FC", "\uA0FD", "\uA0FE", "\uA0FF", "\uA100", "\uA101", "\uA102", "\uA103", "\uA104", "\uA105", "\uA106", "\uA107", "\uA108", "\uA109", "\uA10A", "\uA10B", "\uA10C", "\uA10D", "\uA10E", "\uA10F", "\uA110", "\uA111", "\uA112", "\uA113", "\uA114", "\uA115", "\uA116", "\uA117", "\uA118", "\uA119", "\uA11A", "\uA11B", "\uA11C", "\uA11D", "\uA11E", "\uA11F", "\uA120", "\uA121", "\uA122", "\uA123", "\uA124", "\uA125", "\uA126", "\uA127", "\uA128", "\uA129", "\uA12A", "\uA12B", "\uA12C", "\uA12D", "\uA12E", "\uA12F", "\uA130", "\uA131", "\uA132", "\uA133", "\uA134", "\uA135", "\uA136", "\uA137", "\uA138", "\uA139", "\uA13A", "\uA13B", "\uA13C", "\uA13D", "\uA13E", "\uA13F", "\uA140", "\uA141", "\uA142", "\uA143", "\uA144", "\uA145", "\uA146", "\uA147", "\uA148", "\uA149", "\uA14A", "\uA14B", "\uA14C", "\uA14D", "\uA14E", "\uA14F", "\uA150", "\uA151", "\uA152", "\uA153", "\uA154", "\uA155", "\uA156", "\uA157", "\uA158", "\uA159", "\uA15A", "\uA15B", "\uA15C", "\uA15D", "\uA15E", "\uA15F", "\uA160", "\uA161", "\uA162", "\uA163", "\uA164", "\uA165", "\uA166", "\uA167", "\uA168", "\uA169", "\uA16A", "\uA16B", "\uA16C", "\uA16D", "\uA16E", "\uA16F", "\uA170", "\uA171", "\uA172", "\uA173", "\uA174", "\uA175", "\uA176", "\uA177", "\uA178", "\uA179", "\uA17A", "\uA17B", "\uA17C", "\uA17D", "\uA17E", "\uA17F", "\uA180", "\uA181", "\uA182", "\uA183", "\uA184", "\uA185", "\uA186", "\uA187", "\uA188", "\uA189", "\uA18A", "\uA18B", "\uA18C", "\uA18D", "\uA18E", "\uA18F", "\uA190", "\uA191", "\uA192", "\uA193", "\uA194", "\uA195", "\uA196", "\uA197", "\uA198", "\uA199", "\uA19A", "\uA19B", "\uA19C", "\uA19D", "\uA19E", "\uA19F", "\uA1A0", "\uA1A1", "\uA1A2", "\uA1A3", "\uA1A4", "\uA1A5", "\uA1A6", "\uA1A7", "\uA1A8", "\uA1A9", "\uA1AA", "\uA1AB", "\uA1AC", "\uA1AD", "\uA1AE", "\uA1AF"], false, false),
-      peg$c257 = peg$otherExpectation("Unicode letter number"),
-      peg$c258 = /^[\u16EE\u16EF\u16F0\u2160\u2161\u2162\u2163\u2164\u2165\u2166\u2167\u2168\u2169\u216A\u216B\u216C\u216D\u216E\u216F\u2170\u2171\u2172\u2173\u2174\u2175\u2176\u2177\u2178\u2179\u217A\u217B\u217C\u217D\u217E\u217F\u2180\u2181\u2182\u2185\u2186\u2187\u2188\u3007\u3021\u3022\u3023\u3024\u3025\u3026\u3027\u3028\u3029\u3038\u3039\u303A]/,
-      peg$c259 = peg$classExpectation(["\u16EE", "\u16EF", "\u16F0", "\u2160", "\u2161", "\u2162", "\u2163", "\u2164", "\u2165", "\u2166", "\u2167", "\u2168", "\u2169", "\u216A", "\u216B", "\u216C", "\u216D", "\u216E", "\u216F", "\u2170", "\u2171", "\u2172", "\u2173", "\u2174", "\u2175", "\u2176", "\u2177", "\u2178", "\u2179", "\u217A", "\u217B", "\u217C", "\u217D", "\u217E", "\u217F", "\u2180", "\u2181", "\u2182", "\u2185", "\u2186", "\u2187", "\u2188", "\u3007", "\u3021", "\u3022", "\u3023", "\u3024", "\u3025", "\u3026", "\u3027", "\u3028", "\u3029", "\u3038", "\u3039", "\u303A"], false, false),
-      peg$c260 = peg$otherExpectation("Unicode separator, space"),
-      peg$c261 = /^[ \xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000]/,
-      peg$c262 = peg$classExpectation([" ", "\xA0", "\u1680", "\u180E", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005", "\u2006", "\u2007", "\u2008", "\u2009", "\u200A", "\u202F", "\u205F", "\u3000"], false, false),
-      peg$c263 = function(c) {
+      peg$c230 = /^[0-9]/,
+      peg$c231 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c232 = /^[1-9]/,
+      peg$c233 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c234 = /^[0-9a-fA-F]/,
+      peg$c235 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c236 = peg$otherExpectation("Unicode combining mark"),
+      peg$c237 = /^[\u0903\u093E\u093F\u0940\u0949\u094A\u094B\u094C\u0982\u0983\u09BE\u09BF\u09C0\u09C7\u09C8\u09CB\u09CC\u09D7\u0A03\u0A3E\u0A3F\u0A40\u0A83\u0ABE\u0ABF\u0AC0\u0AC9\u0ACB\u0ACC\u0B02\u0B03\u0B3E\u0B40\u0B47\u0B48\u0B4B\u0B4C\u0B57\u0BBE\u0BBF\u0BC1\u0BC2\u0BC6\u0BC7\u0BC8\u0BCA\u0BCB\u0BCC\u0BD7\u0C01\u0C02\u0C03\u0C41\u0C42\u0C43\u0C44\u0C82\u0C83\u0CBE\u0CC0\u0CC1\u0CC2\u0CC3\u0CC4\u0CC7\u0CC8\u0CCA\u0CCB\u0CD5\u0CD6\u0D02\u0D03\u0D3E\u0D3F\u0D40\u0D46\u0D47\u0D48\u0D4A\u0D4B\u0D4C\u0D57\u0D82\u0D83\u0DCF\u0DD0\u0DD1\u0DD8\u0DD9\u0DDA\u0DDB\u0DDC\u0DDD\u0DDE\u0DDF\u0DF2\u0DF3\u0F3E\u0F3F\u0F7F\u102B\u102C\u1031\u1038\u103B\u103C\u1056\u1057\u1062\u1063\u1064\u1067\u1068\u1069\u106A\u106B\u106C\u106D\u1083\u1084\u1087\u1088\u1089\u108A\u108B\u108C\u108F\u17B6\u17BE\u17BF\u17C0\u17C1\u17C2\u17C3\u17C4\u17C5\u17C7\u17C8\u1923\u1924\u1925\u1926\u1929\u192A\u192B\u1930\u1931\u1933\u1934\u1935\u1936\u1937\u1938\u19B0\u19B1\u19B2\u19B3\u19B4\u19B5\u19B6\u19B7\u19B8\u19B9\u19BA\u19BB\u19BC\u19BD\u19BE\u19BF\u19C0\u19C8\u19C9\u1A19\u1A1A\u1A1B\u1B04\u1B35\u1B3B\u1B3D\u1B3E\u1B3F\u1B40\u1B41\u1B43\u1B44\u1B82\u1BA1\u1BA6\u1BA7\u1BAA\u1C24\u1C25\u1C26\u1C27\u1C28\u1C29\u1C2A\u1C2B\u1C34\u1C35\uA823\uA824\uA827\uA880\uA881\uA8B4\uA8B5\uA8B6\uA8B7\uA8B8\uA8B9\uA8BA\uA8BB\uA8BC\uA8BD\uA8BE\uA8BF\uA8C0\uA8C1\uA8C2\uA8C3\uA952\uA953\uAA2F\uAA30\uAA33\uAA34\uAA4D]/,
+      peg$c238 = peg$classExpectation(["\u0903", "\u093E", "\u093F", "\u0940", "\u0949", "\u094A", "\u094B", "\u094C", "\u0982", "\u0983", "\u09BE", "\u09BF", "\u09C0", "\u09C7", "\u09C8", "\u09CB", "\u09CC", "\u09D7", "\u0A03", "\u0A3E", "\u0A3F", "\u0A40", "\u0A83", "\u0ABE", "\u0ABF", "\u0AC0", "\u0AC9", "\u0ACB", "\u0ACC", "\u0B02", "\u0B03", "\u0B3E", "\u0B40", "\u0B47", "\u0B48", "\u0B4B", "\u0B4C", "\u0B57", "\u0BBE", "\u0BBF", "\u0BC1", "\u0BC2", "\u0BC6", "\u0BC7", "\u0BC8", "\u0BCA", "\u0BCB", "\u0BCC", "\u0BD7", "\u0C01", "\u0C02", "\u0C03", "\u0C41", "\u0C42", "\u0C43", "\u0C44", "\u0C82", "\u0C83", "\u0CBE", "\u0CC0", "\u0CC1", "\u0CC2", "\u0CC3", "\u0CC4", "\u0CC7", "\u0CC8", "\u0CCA", "\u0CCB", "\u0CD5", "\u0CD6", "\u0D02", "\u0D03", "\u0D3E", "\u0D3F", "\u0D40", "\u0D46", "\u0D47", "\u0D48", "\u0D4A", "\u0D4B", "\u0D4C", "\u0D57", "\u0D82", "\u0D83", "\u0DCF", "\u0DD0", "\u0DD1", "\u0DD8", "\u0DD9", "\u0DDA", "\u0DDB", "\u0DDC", "\u0DDD", "\u0DDE", "\u0DDF", "\u0DF2", "\u0DF3", "\u0F3E", "\u0F3F", "\u0F7F", "\u102B", "\u102C", "\u1031", "\u1038", "\u103B", "\u103C", "\u1056", "\u1057", "\u1062", "\u1063", "\u1064", "\u1067", "\u1068", "\u1069", "\u106A", "\u106B", "\u106C", "\u106D", "\u1083", "\u1084", "\u1087", "\u1088", "\u1089", "\u108A", "\u108B", "\u108C", "\u108F", "\u17B6", "\u17BE", "\u17BF", "\u17C0", "\u17C1", "\u17C2", "\u17C3", "\u17C4", "\u17C5", "\u17C7", "\u17C8", "\u1923", "\u1924", "\u1925", "\u1926", "\u1929", "\u192A", "\u192B", "\u1930", "\u1931", "\u1933", "\u1934", "\u1935", "\u1936", "\u1937", "\u1938", "\u19B0", "\u19B1", "\u19B2", "\u19B3", "\u19B4", "\u19B5", "\u19B6", "\u19B7", "\u19B8", "\u19B9", "\u19BA", "\u19BB", "\u19BC", "\u19BD", "\u19BE", "\u19BF", "\u19C0", "\u19C8", "\u19C9", "\u1A19", "\u1A1A", "\u1A1B", "\u1B04", "\u1B35", "\u1B3B", "\u1B3D", "\u1B3E", "\u1B3F", "\u1B40", "\u1B41", "\u1B43", "\u1B44", "\u1B82", "\u1BA1", "\u1BA6", "\u1BA7", "\u1BAA", "\u1C24", "\u1C25", "\u1C26", "\u1C27", "\u1C28", "\u1C29", "\u1C2A", "\u1C2B", "\u1C34", "\u1C35", "\uA823", "\uA824", "\uA827", "\uA880", "\uA881", "\uA8B4", "\uA8B5", "\uA8B6", "\uA8B7", "\uA8B8", "\uA8B9", "\uA8BA", "\uA8BB", "\uA8BC", "\uA8BD", "\uA8BE", "\uA8BF", "\uA8C0", "\uA8C1", "\uA8C2", "\uA8C3", "\uA952", "\uA953", "\uAA2F", "\uAA30", "\uAA33", "\uAA34", "\uAA4D"], false, false),
+      peg$c239 = peg$otherExpectation("Unicode decimal number"),
+      peg$c240 = /^[0123456789\u0660\u0661\u0662\u0663\u0664\u0665\u0666\u0667\u0668\u0669\u06F0\u06F1\u06F2\u06F3\u06F4\u06F5\u06F6\u06F7\u06F8\u06F9\u07C0\u07C1\u07C2\u07C3\u07C4\u07C5\u07C6\u07C7\u07C8\u07C9\u0966\u0967\u0968\u0969\u096A\u096B\u096C\u096D\u096E\u096F\u09E6\u09E7\u09E8\u09E9\u09EA\u09EB\u09EC\u09ED\u09EE\u09EF\u0A66\u0A67\u0A68\u0A69\u0A6A\u0A6B\u0A6C\u0A6D\u0A6E\u0A6F\u0AE6\u0AE7\u0AE8\u0AE9\u0AEA\u0AEB\u0AEC\u0AED\u0AEE\u0AEF\u0B66\u0B67\u0B68\u0B69\u0B6A\u0B6B\u0B6C\u0B6D\u0B6E\u0B6F\u0BE6\u0BE7\u0BE8\u0BE9\u0BEA\u0BEB\u0BEC\u0BED\u0BEE\u0BEF\u0C66\u0C67\u0C68\u0C69\u0C6A\u0C6B\u0C6C\u0C6D\u0C6E\u0C6F\u0CE6\u0CE7\u0CE8\u0CE9\u0CEA\u0CEB\u0CEC\u0CED\u0CEE\u0CEF\u0D66\u0D67\u0D68\u0D69\u0D6A\u0D6B\u0D6C\u0D6D\u0D6E\u0D6F\u0E50\u0E51\u0E52\u0E53\u0E54\u0E55\u0E56\u0E57\u0E58\u0E59\u0ED0\u0ED1\u0ED2\u0ED3\u0ED4\u0ED5\u0ED6\u0ED7\u0ED8\u0ED9\u0F20\u0F21\u0F22\u0F23\u0F24\u0F25\u0F26\u0F27\u0F28\u0F29\u1040\u1041\u1042\u1043\u1044\u1045\u1046\u1047\u1048\u1049\u1090\u1091\u1092\u1093\u1094\u1095\u1096\u1097\u1098\u1099\u17E0\u17E1\u17E2\u17E3\u17E4\u17E5\u17E6\u17E7\u17E8\u17E9\u1810\u1811\u1812\u1813\u1814\u1815\u1816\u1817\u1818\u1819\u1946\u1947\u1948\u1949\u194A\u194B\u194C\u194D\u194E\u194F\u19D0\u19D1\u19D2\u19D3\u19D4\u19D5\u19D6\u19D7\u19D8\u19D9\u1B50\u1B51\u1B52\u1B53\u1B54\u1B55\u1B56\u1B57\u1B58\u1B59\u1BB0\u1BB1\u1BB2\u1BB3\u1BB4\u1BB5\u1BB6\u1BB7\u1BB8\u1BB9\u1C40\u1C41\u1C42\u1C43\u1C44\u1C45\u1C46\u1C47\u1C48\u1C49\u1C50\u1C51\u1C52\u1C53\u1C54\u1C55\u1C56\u1C57\u1C58\u1C59\uA620\uA621\uA622\uA623\uA624\uA625\uA626\uA627\uA628\uA629\uA8D0\uA8D1\uA8D2\uA8D3\uA8D4\uA8D5\uA8D6\uA8D7\uA8D8\uA8D9\uA900\uA901\uA902\uA903\uA904\uA905\uA906\uA907\uA908\uA909\uAA50\uAA51\uAA52\uAA53\uAA54\uAA55\uAA56\uAA57\uAA58\uAA59\uFF10\uFF11\uFF12\uFF13\uFF14\uFF15\uFF16\uFF17\uFF18\uFF19]/,
+      peg$c241 = peg$classExpectation(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669", "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9", "\u07C0", "\u07C1", "\u07C2", "\u07C3", "\u07C4", "\u07C5", "\u07C6", "\u07C7", "\u07C8", "\u07C9", "\u0966", "\u0967", "\u0968", "\u0969", "\u096A", "\u096B", "\u096C", "\u096D", "\u096E", "\u096F", "\u09E6", "\u09E7", "\u09E8", "\u09E9", "\u09EA", "\u09EB", "\u09EC", "\u09ED", "\u09EE", "\u09EF", "\u0A66", "\u0A67", "\u0A68", "\u0A69", "\u0A6A", "\u0A6B", "\u0A6C", "\u0A6D", "\u0A6E", "\u0A6F", "\u0AE6", "\u0AE7", "\u0AE8", "\u0AE9", "\u0AEA", "\u0AEB", "\u0AEC", "\u0AED", "\u0AEE", "\u0AEF", "\u0B66", "\u0B67", "\u0B68", "\u0B69", "\u0B6A", "\u0B6B", "\u0B6C", "\u0B6D", "\u0B6E", "\u0B6F", "\u0BE6", "\u0BE7", "\u0BE8", "\u0BE9", "\u0BEA", "\u0BEB", "\u0BEC", "\u0BED", "\u0BEE", "\u0BEF", "\u0C66", "\u0C67", "\u0C68", "\u0C69", "\u0C6A", "\u0C6B", "\u0C6C", "\u0C6D", "\u0C6E", "\u0C6F", "\u0CE6", "\u0CE7", "\u0CE8", "\u0CE9", "\u0CEA", "\u0CEB", "\u0CEC", "\u0CED", "\u0CEE", "\u0CEF", "\u0D66", "\u0D67", "\u0D68", "\u0D69", "\u0D6A", "\u0D6B", "\u0D6C", "\u0D6D", "\u0D6E", "\u0D6F", "\u0E50", "\u0E51", "\u0E52", "\u0E53", "\u0E54", "\u0E55", "\u0E56", "\u0E57", "\u0E58", "\u0E59", "\u0ED0", "\u0ED1", "\u0ED2", "\u0ED3", "\u0ED4", "\u0ED5", "\u0ED6", "\u0ED7", "\u0ED8", "\u0ED9", "\u0F20", "\u0F21", "\u0F22", "\u0F23", "\u0F24", "\u0F25", "\u0F26", "\u0F27", "\u0F28", "\u0F29", "\u1040", "\u1041", "\u1042", "\u1043", "\u1044", "\u1045", "\u1046", "\u1047", "\u1048", "\u1049", "\u1090", "\u1091", "\u1092", "\u1093", "\u1094", "\u1095", "\u1096", "\u1097", "\u1098", "\u1099", "\u17E0", "\u17E1", "\u17E2", "\u17E3", "\u17E4", "\u17E5", "\u17E6", "\u17E7", "\u17E8", "\u17E9", "\u1810", "\u1811", "\u1812", "\u1813", "\u1814", "\u1815", "\u1816", "\u1817", "\u1818", "\u1819", "\u1946", "\u1947", "\u1948", "\u1949", "\u194A", "\u194B", "\u194C", "\u194D", "\u194E", "\u194F", "\u19D0", "\u19D1", "\u19D2", "\u19D3", "\u19D4", "\u19D5", "\u19D6", "\u19D7", "\u19D8", "\u19D9", "\u1B50", "\u1B51", "\u1B52", "\u1B53", "\u1B54", "\u1B55", "\u1B56", "\u1B57", "\u1B58", "\u1B59", "\u1BB0", "\u1BB1", "\u1BB2", "\u1BB3", "\u1BB4", "\u1BB5", "\u1BB6", "\u1BB7", "\u1BB8", "\u1BB9", "\u1C40", "\u1C41", "\u1C42", "\u1C43", "\u1C44", "\u1C45", "\u1C46", "\u1C47", "\u1C48", "\u1C49", "\u1C50", "\u1C51", "\u1C52", "\u1C53", "\u1C54", "\u1C55", "\u1C56", "\u1C57", "\u1C58", "\u1C59", "\uA620", "\uA621", "\uA622", "\uA623", "\uA624", "\uA625", "\uA626", "\uA627", "\uA628", "\uA629", "\uA8D0", "\uA8D1", "\uA8D2", "\uA8D3", "\uA8D4", "\uA8D5", "\uA8D6", "\uA8D7", "\uA8D8", "\uA8D9", "\uA900", "\uA901", "\uA902", "\uA903", "\uA904", "\uA905", "\uA906", "\uA907", "\uA908", "\uA909", "\uAA50", "\uAA51", "\uAA52", "\uAA53", "\uAA54", "\uAA55", "\uAA56", "\uAA57", "\uAA58", "\uAA59", "\uFF10", "\uFF11", "\uFF12", "\uFF13", "\uFF14", "\uFF15", "\uFF16", "\uFF17", "\uFF18", "\uFF19"], false, false),
+      peg$c242 = peg$otherExpectation("Unicode punctuation connector"),
+      peg$c243 = /^[_\u203F\u2040\u2054\uFE33\uFE34\uFE4D\uFE4E\uFE4F\uFF3F]/,
+      peg$c244 = peg$classExpectation(["_", "\u203F", "\u2040", "\u2054", "\uFE33", "\uFE34", "\uFE4D", "\uFE4E", "\uFE4F", "\uFF3F"], false, false),
+      peg$c245 = peg$otherExpectation("Unicode uppercase letter"),
+      peg$c246 = /^[ABCDEFGHIJKLMNOPQRSTUVWXYZ\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD8\xD9\xDA\xDB\xDC\xDD\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178\u0179\u017B\u017D\u0181\u0182\u0184\u0186\u0187\u0189\u018A\u018B\u018E\u018F\u0190\u0191\u0193\u0194\u0196\u0197\u0198\u019C\u019D\u019F\u01A0\u01A2\u01A4\u01A6\u01A7\u01A9\u01AC\u01AE\u01AF\u01B1\u01B2\u01B3\u01B5\u01B7\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6\u01F7\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A\u023B\u023D\u023E\u0241\u0243\u0244\u0245\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u0386\u0388\u0389\u038A\u038C\u038E\u038F\u0391\u0392\u0393\u0394\u0395\u0396\u0397\u0398\u0399\u039A\u039B\u039C\u039D\u039E\u039F\u03A0\u03A1\u03A3\u03A4\u03A5\u03A6\u03A7\u03A8\u03A9\u03AA\u03AB\u03CF\u03D2\u03D3\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9\u03FA\u03FD\u03FE\u03FF\u0400\u0401\u0402\u0403\u0404\u0405\u0406\u0407\u0408\u0409\u040A\u040B\u040C\u040D\u040E\u040F\u0410\u0411\u0412\u0413\u0414\u0415\u0416\u0417\u0418\u0419\u041A\u041B\u041C\u041D\u041E\u041F\u0420\u0421\u0422\u0423\u0424\u0425\u0426\u0427\u0428\u0429\u042A\u042B\u042C\u042D\u042E\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0531\u0532\u0533\u0534\u0535\u0536\u0537\u0538\u0539\u053A\u053B\u053C\u053D\u053E\u053F\u0540\u0541\u0542\u0543\u0544\u0545\u0546\u0547\u0548\u0549\u054A\u054B\u054C\u054D\u054E\u054F\u0550\u0551\u0552\u0553\u0554\u0555\u0556\u10A0\u10A1\u10A2\u10A3\u10A4\u10A5\u10A6\u10A7\u10A8\u10A9\u10AA\u10AB\u10AC\u10AD\u10AE\u10AF\u10B0\u10B1\u10B2\u10B3\u10B4\u10B5\u10B6\u10B7\u10B8\u10B9\u10BA\u10BB\u10BC\u10BD\u10BE\u10BF\u10C0\u10C1\u10C2\u10C3\u10C4\u10C5\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08\u1F09\u1F0A\u1F0B\u1F0C\u1F0D\u1F0E\u1F0F\u1F18\u1F19\u1F1A\u1F1B\u1F1C\u1F1D\u1F28\u1F29\u1F2A\u1F2B\u1F2C\u1F2D\u1F2E\u1F2F\u1F38\u1F39\u1F3A\u1F3B\u1F3C\u1F3D\u1F3E\u1F3F\u1F48\u1F49\u1F4A\u1F4B\u1F4C\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68\u1F69\u1F6A\u1F6B\u1F6C\u1F6D\u1F6E\u1F6F\u1FB8\u1FB9\u1FBA\u1FBB\u1FC8\u1FC9\u1FCA\u1FCB\u1FD8\u1FD9\u1FDA\u1FDB\u1FE8\u1FE9\u1FEA\u1FEB\u1FEC\u1FF8\u1FF9\u1FFA\u1FFB\u2102\u2107\u210B\u210C\u210D\u2110\u2111\u2112\u2115\u2119\u211A\u211B\u211C\u211D\u2124\u2126\u2128\u212A\u212B\u212C\u212D\u2130\u2131\u2132\u2133\u213E\u213F\u2145\u2183\u2C00\u2C01\u2C02\u2C03\u2C04\u2C05\u2C06\u2C07\u2C08\u2C09\u2C0A\u2C0B\u2C0C\u2C0D\u2C0E\u2C0F\u2C10\u2C11\u2C12\u2C13\u2C14\u2C15\u2C16\u2C17\u2C18\u2C19\u2C1A\u2C1B\u2C1C\u2C1D\u2C1E\u2C1F\u2C20\u2C21\u2C22\u2C23\u2C24\u2C25\u2C26\u2C27\u2C28\u2C29\u2C2A\u2C2B\u2C2C\u2C2D\u2C2E\u2C60\u2C62\u2C63\u2C64\u2C67\u2C69\u2C6B\u2C6D\u2C6E\u2C6F\u2C72\u2C75\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D\uA77E\uA780\uA782\uA784\uA786\uA78B\uFF21\uFF22\uFF23\uFF24\uFF25\uFF26\uFF27\uFF28\uFF29\uFF2A\uFF2B\uFF2C\uFF2D\uFF2E\uFF2F\uFF30\uFF31\uFF32\uFF33\uFF34\uFF35\uFF36\uFF37\uFF38\uFF39\uFF3A]/,
+      peg$c247 = peg$classExpectation(["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "\xC0", "\xC1", "\xC2", "\xC3", "\xC4", "\xC5", "\xC6", "\xC7", "\xC8", "\xC9", "\xCA", "\xCB", "\xCC", "\xCD", "\xCE", "\xCF", "\xD0", "\xD1", "\xD2", "\xD3", "\xD4", "\xD5", "\xD6", "\xD8", "\xD9", "\xDA", "\xDB", "\xDC", "\xDD", "\xDE", "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", "\u0178", "\u0179", "\u017B", "\u017D", "\u0181", "\u0182", "\u0184", "\u0186", "\u0187", "\u0189", "\u018A", "\u018B", "\u018E", "\u018F", "\u0190", "\u0191", "\u0193", "\u0194", "\u0196", "\u0197", "\u0198", "\u019C", "\u019D", "\u019F", "\u01A0", "\u01A2", "\u01A4", "\u01A6", "\u01A7", "\u01A9", "\u01AC", "\u01AE", "\u01AF", "\u01B1", "\u01B2", "\u01B3", "\u01B5", "\u01B7", "\u01B8", "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", "\u01F6", "\u01F7", "\u01F8", "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", "\u023A", "\u023B", "\u023D", "\u023E", "\u0241", "\u0243", "\u0244", "\u0245", "\u0246", "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u0386", "\u0388", "\u0389", "\u038A", "\u038C", "\u038E", "\u038F", "\u0391", "\u0392", "\u0393", "\u0394", "\u0395", "\u0396", "\u0397", "\u0398", "\u0399", "\u039A", "\u039B", "\u039C", "\u039D", "\u039E", "\u039F", "\u03A0", "\u03A1", "\u03A3", "\u03A4", "\u03A5", "\u03A6", "\u03A7", "\u03A8", "\u03A9", "\u03AA", "\u03AB", "\u03CF", "\u03D2", "\u03D3", "\u03D4", "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", "\u03F9", "\u03FA", "\u03FD", "\u03FE", "\u03FF", "\u0400", "\u0401", "\u0402", "\u0403", "\u0404", "\u0405", "\u0406", "\u0407", "\u0408", "\u0409", "\u040A", "\u040B", "\u040C", "\u040D", "\u040E", "\u040F", "\u0410", "\u0411", "\u0412", "\u0413", "\u0414", "\u0415", "\u0416", "\u0417", "\u0418", "\u0419", "\u041A", "\u041B", "\u041C", "\u041D", "\u041E", "\u041F", "\u0420", "\u0421", "\u0422", "\u0423", "\u0424", "\u0425", "\u0426", "\u0427", "\u0428", "\u0429", "\u042A", "\u042B", "\u042C", "\u042D", "\u042E", "\u042F", "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", "\u04C0", "\u04C1", "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0531", "\u0532", "\u0533", "\u0534", "\u0535", "\u0536", "\u0537", "\u0538", "\u0539", "\u053A", "\u053B", "\u053C", "\u053D", "\u053E", "\u053F", "\u0540", "\u0541", "\u0542", "\u0543", "\u0544", "\u0545", "\u0546", "\u0547", "\u0548", "\u0549", "\u054A", "\u054B", "\u054C", "\u054D", "\u054E", "\u054F", "\u0550", "\u0551", "\u0552", "\u0553", "\u0554", "\u0555", "\u0556", "\u10A0", "\u10A1", "\u10A2", "\u10A3", "\u10A4", "\u10A5", "\u10A6", "\u10A7", "\u10A8", "\u10A9", "\u10AA", "\u10AB", "\u10AC", "\u10AD", "\u10AE", "\u10AF", "\u10B0", "\u10B1", "\u10B2", "\u10B3", "\u10B4", "\u10B5", "\u10B6", "\u10B7", "\u10B8", "\u10B9", "\u10BA", "\u10BB", "\u10BC", "\u10BD", "\u10BE", "\u10BF", "\u10C0", "\u10C1", "\u10C2", "\u10C3", "\u10C4", "\u10C5", "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", "\u1F08", "\u1F09", "\u1F0A", "\u1F0B", "\u1F0C", "\u1F0D", "\u1F0E", "\u1F0F", "\u1F18", "\u1F19", "\u1F1A", "\u1F1B", "\u1F1C", "\u1F1D", "\u1F28", "\u1F29", "\u1F2A", "\u1F2B", "\u1F2C", "\u1F2D", "\u1F2E", "\u1F2F", "\u1F38", "\u1F39", "\u1F3A", "\u1F3B", "\u1F3C", "\u1F3D", "\u1F3E", "\u1F3F", "\u1F48", "\u1F49", "\u1F4A", "\u1F4B", "\u1F4C", "\u1F4D", "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", "\u1F68", "\u1F69", "\u1F6A", "\u1F6B", "\u1F6C", "\u1F6D", "\u1F6E", "\u1F6F", "\u1FB8", "\u1FB9", "\u1FBA", "\u1FBB", "\u1FC8", "\u1FC9", "\u1FCA", "\u1FCB", "\u1FD8", "\u1FD9", "\u1FDA", "\u1FDB", "\u1FE8", "\u1FE9", "\u1FEA", "\u1FEB", "\u1FEC", "\u1FF8", "\u1FF9", "\u1FFA", "\u1FFB", "\u2102", "\u2107", "\u210B", "\u210C", "\u210D", "\u2110", "\u2111", "\u2112", "\u2115", "\u2119", "\u211A", "\u211B", "\u211C", "\u211D", "\u2124", "\u2126", "\u2128", "\u212A", "\u212B", "\u212C", "\u212D", "\u2130", "\u2131", "\u2132", "\u2133", "\u213E", "\u213F", "\u2145", "\u2183", "\u2C00", "\u2C01", "\u2C02", "\u2C03", "\u2C04", "\u2C05", "\u2C06", "\u2C07", "\u2C08", "\u2C09", "\u2C0A", "\u2C0B", "\u2C0C", "\u2C0D", "\u2C0E", "\u2C0F", "\u2C10", "\u2C11", "\u2C12", "\u2C13", "\u2C14", "\u2C15", "\u2C16", "\u2C17", "\u2C18", "\u2C19", "\u2C1A", "\u2C1B", "\u2C1C", "\u2C1D", "\u2C1E", "\u2C1F", "\u2C20", "\u2C21", "\u2C22", "\u2C23", "\u2C24", "\u2C25", "\u2C26", "\u2C27", "\u2C28", "\u2C29", "\u2C2A", "\u2C2B", "\u2C2C", "\u2C2D", "\u2C2E", "\u2C60", "\u2C62", "\u2C63", "\u2C64", "\u2C67", "\u2C69", "\u2C6B", "\u2C6D", "\u2C6E", "\u2C6F", "\u2C72", "\u2C75", "\u2C80", "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", "\uA77D", "\uA77E", "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uFF21", "\uFF22", "\uFF23", "\uFF24", "\uFF25", "\uFF26", "\uFF27", "\uFF28", "\uFF29", "\uFF2A", "\uFF2B", "\uFF2C", "\uFF2D", "\uFF2E", "\uFF2F", "\uFF30", "\uFF31", "\uFF32", "\uFF33", "\uFF34", "\uFF35", "\uFF36", "\uFF37", "\uFF38", "\uFF39", "\uFF3A"], false, false),
+      peg$c248 = peg$otherExpectation("Unicode lowercase letter"),
+      peg$c249 = /^[abcdefghijklmnopqrstuvwxyz\xAA\xB5\xBA\xDF\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E\u017F\u0180\u0183\u0185\u0188\u018C\u018D\u0192\u0195\u0199\u019A\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9\u01BA\u01BD\u01BE\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233\u0234\u0235\u0236\u0237\u0238\u0239\u023C\u023F\u0240\u0242\u0247\u0249\u024B\u024D\u024F\u0250\u0251\u0252\u0253\u0254\u0255\u0256\u0257\u0258\u0259\u025A\u025B\u025C\u025D\u025E\u025F\u0260\u0261\u0262\u0263\u0264\u0265\u0266\u0267\u0268\u0269\u026A\u026B\u026C\u026D\u026E\u026F\u0270\u0271\u0272\u0273\u0274\u0275\u0276\u0277\u0278\u0279\u027A\u027B\u027C\u027D\u027E\u027F\u0280\u0281\u0282\u0283\u0284\u0285\u0286\u0287\u0288\u0289\u028A\u028B\u028C\u028D\u028E\u028F\u0290\u0291\u0292\u0293\u0295\u0296\u0297\u0298\u0299\u029A\u029B\u029C\u029D\u029E\u029F\u02A0\u02A1\u02A2\u02A3\u02A4\u02A5\u02A6\u02A7\u02A8\u02A9\u02AA\u02AB\u02AC\u02AD\u02AE\u02AF\u0371\u0373\u0377\u037B\u037C\u037D\u0390\u03AC\u03AD\u03AE\u03AF\u03B0\u03B1\u03B2\u03B3\u03B4\u03B5\u03B6\u03B7\u03B8\u03B9\u03BA\u03BB\u03BC\u03BD\u03BE\u03BF\u03C0\u03C1\u03C2\u03C3\u03C4\u03C5\u03C6\u03C7\u03C8\u03C9\u03CA\u03CB\u03CC\u03CD\u03CE\u03D0\u03D1\u03D5\u03D6\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF\u03F0\u03F1\u03F2\u03F3\u03F5\u03F8\u03FB\u03FC\u0430\u0431\u0432\u0433\u0434\u0435\u0436\u0437\u0438\u0439\u043A\u043B\u043C\u043D\u043E\u043F\u0440\u0441\u0442\u0443\u0444\u0445\u0446\u0447\u0448\u0449\u044A\u044B\u044C\u044D\u044E\u044F\u0450\u0451\u0452\u0453\u0454\u0455\u0456\u0457\u0458\u0459\u045A\u045B\u045C\u045D\u045E\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0561\u0562\u0563\u0564\u0565\u0566\u0567\u0568\u0569\u056A\u056B\u056C\u056D\u056E\u056F\u0570\u0571\u0572\u0573\u0574\u0575\u0576\u0577\u0578\u0579\u057A\u057B\u057C\u057D\u057E\u057F\u0580\u0581\u0582\u0583\u0584\u0585\u0586\u0587\u1D00\u1D01\u1D02\u1D03\u1D04\u1D05\u1D06\u1D07\u1D08\u1D09\u1D0A\u1D0B\u1D0C\u1D0D\u1D0E\u1D0F\u1D10\u1D11\u1D12\u1D13\u1D14\u1D15\u1D16\u1D17\u1D18\u1D19\u1D1A\u1D1B\u1D1C\u1D1D\u1D1E\u1D1F\u1D20\u1D21\u1D22\u1D23\u1D24\u1D25\u1D26\u1D27\u1D28\u1D29\u1D2A\u1D2B\u1D62\u1D63\u1D64\u1D65\u1D66\u1D67\u1D68\u1D69\u1D6A\u1D6B\u1D6C\u1D6D\u1D6E\u1D6F\u1D70\u1D71\u1D72\u1D73\u1D74\u1D75\u1D76\u1D77\u1D79\u1D7A\u1D7B\u1D7C\u1D7D\u1D7E\u1D7F\u1D80\u1D81\u1D82\u1D83\u1D84\u1D85\u1D86\u1D87\u1D88\u1D89\u1D8A\u1D8B\u1D8C\u1D8D\u1D8E\u1D8F\u1D90\u1D91\u1D92\u1D93\u1D94\u1D95\u1D96\u1D97\u1D98\u1D99\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95\u1E96\u1E97\u1E98\u1E99\u1E9A\u1E9B\u1E9C\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF\u1F00\u1F01\u1F02\u1F03\u1F04\u1F05\u1F06\u1F07\u1F10\u1F11\u1F12\u1F13\u1F14\u1F15\u1F20\u1F21\u1F22\u1F23\u1F24\u1F25\u1F26\u1F27\u1F30\u1F31\u1F32\u1F33\u1F34\u1F35\u1F36\u1F37\u1F40\u1F41\u1F42\u1F43\u1F44\u1F45\u1F50\u1F51\u1F52\u1F53\u1F54\u1F55\u1F56\u1F57\u1F60\u1F61\u1F62\u1F63\u1F64\u1F65\u1F66\u1F67\u1F70\u1F71\u1F72\u1F73\u1F74\u1F75\u1F76\u1F77\u1F78\u1F79\u1F7A\u1F7B\u1F7C\u1F7D\u1F80\u1F81\u1F82\u1F83\u1F84\u1F85\u1F86\u1F87\u1F90\u1F91\u1F92\u1F93\u1F94\u1F95\u1F96\u1F97\u1FA0\u1FA1\u1FA2\u1FA3\u1FA4\u1FA5\u1FA6\u1FA7\u1FB0\u1FB1\u1FB2\u1FB3\u1FB4\u1FB6\u1FB7\u1FBE\u1FC2\u1FC3\u1FC4\u1FC6\u1FC7\u1FD0\u1FD1\u1FD2\u1FD3\u1FD6\u1FD7\u1FE0\u1FE1\u1FE2\u1FE3\u1FE4\u1FE5\u1FE6\u1FE7\u1FF2\u1FF3\u1FF4\u1FF6\u1FF7\u2071\u207F\u210A\u210E\u210F\u2113\u212F\u2134\u2139\u213C\u213D\u2146\u2147\u2148\u2149\u214E\u2184\u2C30\u2C31\u2C32\u2C33\u2C34\u2C35\u2C36\u2C37\u2C38\u2C39\u2C3A\u2C3B\u2C3C\u2C3D\u2C3E\u2C3F\u2C40\u2C41\u2C42\u2C43\u2C44\u2C45\u2C46\u2C47\u2C48\u2C49\u2C4A\u2C4B\u2C4C\u2C4D\u2C4E\u2C4F\u2C50\u2C51\u2C52\u2C53\u2C54\u2C55\u2C56\u2C57\u2C58\u2C59\u2C5A\u2C5B\u2C5C\u2C5D\u2C5E\u2C61\u2C65\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73\u2C74\u2C76\u2C77\u2C78\u2C79\u2C7A\u2C7B\u2C7C\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3\u2CE4\u2D00\u2D01\u2D02\u2D03\u2D04\u2D05\u2D06\u2D07\u2D08\u2D09\u2D0A\u2D0B\u2D0C\u2D0D\u2D0E\u2D0F\u2D10\u2D11\u2D12\u2D13\u2D14\u2D15\u2D16\u2D17\u2D18\u2D19\u2D1A\u2D1B\u2D1C\u2D1D\u2D1E\u2D1F\u2D20\u2D21\u2D22\u2D23\u2D24\u2D25\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F\uA730\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771\uA772\uA773\uA774\uA775\uA776\uA777\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uFB00\uFB01\uFB02\uFB03\uFB04\uFB05\uFB06\uFB13\uFB14\uFB15\uFB16\uFB17\uFF41\uFF42\uFF43\uFF44\uFF45\uFF46\uFF47\uFF48\uFF49\uFF4A\uFF4B\uFF4C\uFF4D\uFF4E\uFF4F\uFF50\uFF51\uFF52\uFF53\uFF54\uFF55\uFF56\uFF57\uFF58\uFF59\uFF5A]/,
+      peg$c250 = peg$classExpectation(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "\xAA", "\xB5", "\xBA", "\xDF", "\xE0", "\xE1", "\xE2", "\xE3", "\xE4", "\xE5", "\xE6", "\xE7", "\xE8", "\xE9", "\xEA", "\xEB", "\xEC", "\xED", "\xEE", "\xEF", "\xF0", "\xF1", "\xF2", "\xF3", "\xF4", "\xF5", "\xF6", "\xF8", "\xF9", "\xFA", "\xFB", "\xFC", "\xFD", "\xFE", "\xFF", "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", "\u0137", "\u0138", "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", "\u0148", "\u0149", "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", "\u017E", "\u017F", "\u0180", "\u0183", "\u0185", "\u0188", "\u018C", "\u018D", "\u0192", "\u0195", "\u0199", "\u019A", "\u019B", "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", "\u01AA", "\u01AB", "\u01AD", "\u01B0", "\u01B4", "\u01B6", "\u01B9", "\u01BA", "\u01BD", "\u01BE", "\u01BF", "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", "\u01DC", "\u01DD", "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", "\u01EF", "\u01F0", "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", "\u0233", "\u0234", "\u0235", "\u0236", "\u0237", "\u0238", "\u0239", "\u023C", "\u023F", "\u0240", "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", "\u024F", "\u0250", "\u0251", "\u0252", "\u0253", "\u0254", "\u0255", "\u0256", "\u0257", "\u0258", "\u0259", "\u025A", "\u025B", "\u025C", "\u025D", "\u025E", "\u025F", "\u0260", "\u0261", "\u0262", "\u0263", "\u0264", "\u0265", "\u0266", "\u0267", "\u0268", "\u0269", "\u026A", "\u026B", "\u026C", "\u026D", "\u026E", "\u026F", "\u0270", "\u0271", "\u0272", "\u0273", "\u0274", "\u0275", "\u0276", "\u0277", "\u0278", "\u0279", "\u027A", "\u027B", "\u027C", "\u027D", "\u027E", "\u027F", "\u0280", "\u0281", "\u0282", "\u0283", "\u0284", "\u0285", "\u0286", "\u0287", "\u0288", "\u0289", "\u028A", "\u028B", "\u028C", "\u028D", "\u028E", "\u028F", "\u0290", "\u0291", "\u0292", "\u0293", "\u0295", "\u0296", "\u0297", "\u0298", "\u0299", "\u029A", "\u029B", "\u029C", "\u029D", "\u029E", "\u029F", "\u02A0", "\u02A1", "\u02A2", "\u02A3", "\u02A4", "\u02A5", "\u02A6", "\u02A7", "\u02A8", "\u02A9", "\u02AA", "\u02AB", "\u02AC", "\u02AD", "\u02AE", "\u02AF", "\u0371", "\u0373", "\u0377", "\u037B", "\u037C", "\u037D", "\u0390", "\u03AC", "\u03AD", "\u03AE", "\u03AF", "\u03B0", "\u03B1", "\u03B2", "\u03B3", "\u03B4", "\u03B5", "\u03B6", "\u03B7", "\u03B8", "\u03B9", "\u03BA", "\u03BB", "\u03BC", "\u03BD", "\u03BE", "\u03BF", "\u03C0", "\u03C1", "\u03C2", "\u03C3", "\u03C4", "\u03C5", "\u03C6", "\u03C7", "\u03C8", "\u03C9", "\u03CA", "\u03CB", "\u03CC", "\u03CD", "\u03CE", "\u03D0", "\u03D1", "\u03D5", "\u03D6", "\u03D7", "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", "\u03EF", "\u03F0", "\u03F1", "\u03F2", "\u03F3", "\u03F5", "\u03F8", "\u03FB", "\u03FC", "\u0430", "\u0431", "\u0432", "\u0433", "\u0434", "\u0435", "\u0436", "\u0437", "\u0438", "\u0439", "\u043A", "\u043B", "\u043C", "\u043D", "\u043E", "\u043F", "\u0440", "\u0441", "\u0442", "\u0443", "\u0444", "\u0445", "\u0446", "\u0447", "\u0448", "\u0449", "\u044A", "\u044B", "\u044C", "\u044D", "\u044E", "\u044F", "\u0450", "\u0451", "\u0452", "\u0453", "\u0454", "\u0455", "\u0456", "\u0457", "\u0458", "\u0459", "\u045A", "\u045B", "\u045C", "\u045D", "\u045E", "\u045F", "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", "\u04CE", "\u04CF", "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0561", "\u0562", "\u0563", "\u0564", "\u0565", "\u0566", "\u0567", "\u0568", "\u0569", "\u056A", "\u056B", "\u056C", "\u056D", "\u056E", "\u056F", "\u0570", "\u0571", "\u0572", "\u0573", "\u0574", "\u0575", "\u0576", "\u0577", "\u0578", "\u0579", "\u057A", "\u057B", "\u057C", "\u057D", "\u057E", "\u057F", "\u0580", "\u0581", "\u0582", "\u0583", "\u0584", "\u0585", "\u0586", "\u0587", "\u1D00", "\u1D01", "\u1D02", "\u1D03", "\u1D04", "\u1D05", "\u1D06", "\u1D07", "\u1D08", "\u1D09", "\u1D0A", "\u1D0B", "\u1D0C", "\u1D0D", "\u1D0E", "\u1D0F", "\u1D10", "\u1D11", "\u1D12", "\u1D13", "\u1D14", "\u1D15", "\u1D16", "\u1D17", "\u1D18", "\u1D19", "\u1D1A", "\u1D1B", "\u1D1C", "\u1D1D", "\u1D1E", "\u1D1F", "\u1D20", "\u1D21", "\u1D22", "\u1D23", "\u1D24", "\u1D25", "\u1D26", "\u1D27", "\u1D28", "\u1D29", "\u1D2A", "\u1D2B", "\u1D62", "\u1D63", "\u1D64", "\u1D65", "\u1D66", "\u1D67", "\u1D68", "\u1D69", "\u1D6A", "\u1D6B", "\u1D6C", "\u1D6D", "\u1D6E", "\u1D6F", "\u1D70", "\u1D71", "\u1D72", "\u1D73", "\u1D74", "\u1D75", "\u1D76", "\u1D77", "\u1D79", "\u1D7A", "\u1D7B", "\u1D7C", "\u1D7D", "\u1D7E", "\u1D7F", "\u1D80", "\u1D81", "\u1D82", "\u1D83", "\u1D84", "\u1D85", "\u1D86", "\u1D87", "\u1D88", "\u1D89", "\u1D8A", "\u1D8B", "\u1D8C", "\u1D8D", "\u1D8E", "\u1D8F", "\u1D90", "\u1D91", "\u1D92", "\u1D93", "\u1D94", "\u1D95", "\u1D96", "\u1D97", "\u1D98", "\u1D99", "\u1D9A", "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", "\u1E95", "\u1E96", "\u1E97", "\u1E98", "\u1E99", "\u1E9A", "\u1E9B", "\u1E9C", "\u1E9D", "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", "\u1EFF", "\u1F00", "\u1F01", "\u1F02", "\u1F03", "\u1F04", "\u1F05", "\u1F06", "\u1F07", "\u1F10", "\u1F11", "\u1F12", "\u1F13", "\u1F14", "\u1F15", "\u1F20", "\u1F21", "\u1F22", "\u1F23", "\u1F24", "\u1F25", "\u1F26", "\u1F27", "\u1F30", "\u1F31", "\u1F32", "\u1F33", "\u1F34", "\u1F35", "\u1F36", "\u1F37", "\u1F40", "\u1F41", "\u1F42", "\u1F43", "\u1F44", "\u1F45", "\u1F50", "\u1F51", "\u1F52", "\u1F53", "\u1F54", "\u1F55", "\u1F56", "\u1F57", "\u1F60", "\u1F61", "\u1F62", "\u1F63", "\u1F64", "\u1F65", "\u1F66", "\u1F67", "\u1F70", "\u1F71", "\u1F72", "\u1F73", "\u1F74", "\u1F75", "\u1F76", "\u1F77", "\u1F78", "\u1F79", "\u1F7A", "\u1F7B", "\u1F7C", "\u1F7D", "\u1F80", "\u1F81", "\u1F82", "\u1F83", "\u1F84", "\u1F85", "\u1F86", "\u1F87", "\u1F90", "\u1F91", "\u1F92", "\u1F93", "\u1F94", "\u1F95", "\u1F96", "\u1F97", "\u1FA0", "\u1FA1", "\u1FA2", "\u1FA3", "\u1FA4", "\u1FA5", "\u1FA6", "\u1FA7", "\u1FB0", "\u1FB1", "\u1FB2", "\u1FB3", "\u1FB4", "\u1FB6", "\u1FB7", "\u1FBE", "\u1FC2", "\u1FC3", "\u1FC4", "\u1FC6", "\u1FC7", "\u1FD0", "\u1FD1", "\u1FD2", "\u1FD3", "\u1FD6", "\u1FD7", "\u1FE0", "\u1FE1", "\u1FE2", "\u1FE3", "\u1FE4", "\u1FE5", "\u1FE6", "\u1FE7", "\u1FF2", "\u1FF3", "\u1FF4", "\u1FF6", "\u1FF7", "\u2071", "\u207F", "\u210A", "\u210E", "\u210F", "\u2113", "\u212F", "\u2134", "\u2139", "\u213C", "\u213D", "\u2146", "\u2147", "\u2148", "\u2149", "\u214E", "\u2184", "\u2C30", "\u2C31", "\u2C32", "\u2C33", "\u2C34", "\u2C35", "\u2C36", "\u2C37", "\u2C38", "\u2C39", "\u2C3A", "\u2C3B", "\u2C3C", "\u2C3D", "\u2C3E", "\u2C3F", "\u2C40", "\u2C41", "\u2C42", "\u2C43", "\u2C44", "\u2C45", "\u2C46", "\u2C47", "\u2C48", "\u2C49", "\u2C4A", "\u2C4B", "\u2C4C", "\u2C4D", "\u2C4E", "\u2C4F", "\u2C50", "\u2C51", "\u2C52", "\u2C53", "\u2C54", "\u2C55", "\u2C56", "\u2C57", "\u2C58", "\u2C59", "\u2C5A", "\u2C5B", "\u2C5C", "\u2C5D", "\u2C5E", "\u2C61", "\u2C65", "\u2C66", "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", "\u2C73", "\u2C74", "\u2C76", "\u2C77", "\u2C78", "\u2C79", "\u2C7A", "\u2C7B", "\u2C7C", "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", "\u2CE3", "\u2CE4", "\u2D00", "\u2D01", "\u2D02", "\u2D03", "\u2D04", "\u2D05", "\u2D06", "\u2D07", "\u2D08", "\u2D09", "\u2D0A", "\u2D0B", "\u2D0C", "\u2D0D", "\u2D0E", "\u2D0F", "\u2D10", "\u2D11", "\u2D12", "\u2D13", "\u2D14", "\u2D15", "\u2D16", "\u2D17", "\u2D18", "\u2D19", "\u2D1A", "\u2D1B", "\u2D1C", "\u2D1D", "\u2D1E", "\u2D1F", "\u2D20", "\u2D21", "\u2D22", "\u2D23", "\u2D24", "\u2D25", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", "\uA72F", "\uA730", "\uA731", "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", "\uA771", "\uA772", "\uA773", "\uA774", "\uA775", "\uA776", "\uA777", "\uA778", "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uFB00", "\uFB01", "\uFB02", "\uFB03", "\uFB04", "\uFB05", "\uFB06", "\uFB13", "\uFB14", "\uFB15", "\uFB16", "\uFB17", "\uFF41", "\uFF42", "\uFF43", "\uFF44", "\uFF45", "\uFF46", "\uFF47", "\uFF48", "\uFF49", "\uFF4A", "\uFF4B", "\uFF4C", "\uFF4D", "\uFF4E", "\uFF4F", "\uFF50", "\uFF51", "\uFF52", "\uFF53", "\uFF54", "\uFF55", "\uFF56", "\uFF57", "\uFF58", "\uFF59", "\uFF5A"], false, false),
+      peg$c251 = peg$otherExpectation("Unicode titlecase letter"),
+      peg$c252 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88\u1F89\u1F8A\u1F8B\u1F8C\u1F8D\u1F8E\u1F8F\u1F98\u1F99\u1F9A\u1F9B\u1F9C\u1F9D\u1F9E\u1F9F\u1FA8\u1FA9\u1FAA\u1FAB\u1FAC\u1FAD\u1FAE\u1FAF\u1FBC\u1FCC]/,
+      peg$c253 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", "\u1F88", "\u1F89", "\u1F8A", "\u1F8B", "\u1F8C", "\u1F8D", "\u1F8E", "\u1F8F", "\u1F98", "\u1F99", "\u1F9A", "\u1F9B", "\u1F9C", "\u1F9D", "\u1F9E", "\u1F9F", "\u1FA8", "\u1FA9", "\u1FAA", "\u1FAB", "\u1FAC", "\u1FAD", "\u1FAE", "\u1FAF", "\u1FBC", "\u1FCC"], false, false),
+      peg$c254 = peg$otherExpectation("Unicode modifier letter"),
+      peg$c255 = /^[\u02B0\u02B1\u02B2\u02B3\u02B4\u02B5\u02B6\u02B7\u02B8\u02B9\u02BA\u02BB\u02BC\u02BD\u02BE\u02BF\u02C0\u02C1\u02C6\u02C7\u02C8\u02C9\u02CA\u02CB\u02CC\u02CD\u02CE\u02CF\u02D0\u02D1\u02E0\u02E1\u02E2\u02E3\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5\u06E6\u07F4\u07F5\u07FA\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1C78\u1C79\u1C7A\u1C7B\u1C7C\u1C7D\u1D2C\u1D2D\u1D2E\u1D2F\u1D30\u1D31\u1D32\u1D33\u1D34\u1D35\u1D36\u1D37\u1D38\u1D39\u1D3A\u1D3B\u1D3C\u1D3D\u1D3E\u1D3F\u1D40\u1D41\u1D42\u1D43\u1D44\u1D45\u1D46\u1D47\u1D48\u1D49\u1D4A\u1D4B\u1D4C\u1D4D\u1D4E\u1D4F\u1D50\u1D51\u1D52\u1D53\u1D54\u1D55\u1D56\u1D57\u1D58\u1D59\u1D5A\u1D5B\u1D5C\u1D5D\u1D5E\u1D5F\u1D60\u1D61\u1D78\u1D9B\u1D9C\u1D9D\u1D9E\u1D9F\u1DA0\u1DA1\u1DA2\u1DA3\u1DA4\u1DA5\u1DA6\u1DA7\u1DA8\u1DA9\u1DAA\u1DAB\u1DAC\u1DAD\u1DAE\u1DAF\u1DB0\u1DB1\u1DB2\u1DB3\u1DB4\u1DB5\u1DB6\u1DB7\u1DB8\u1DB9\u1DBA\u1DBB\u1DBC\u1DBD\u1DBE\u1DBF\u2090\u2091\u2092\u2093\u2094\u2C7D\u2D6F\u2E2F\u3005\u3031\u3032\u3033\u3034\u3035\u303B\u309D\u309E\u30FC\u30FD\u30FE\uA015\uA60C\uA67F\uA717\uA718\uA719\uA71A\uA71B\uA71C\uA71D\uA71E\uA71F\uA770\uA788\uFF70\uFF9E\uFF9F]/,
+      peg$c256 = peg$classExpectation(["\u02B0", "\u02B1", "\u02B2", "\u02B3", "\u02B4", "\u02B5", "\u02B6", "\u02B7", "\u02B8", "\u02B9", "\u02BA", "\u02BB", "\u02BC", "\u02BD", "\u02BE", "\u02BF", "\u02C0", "\u02C1", "\u02C6", "\u02C7", "\u02C8", "\u02C9", "\u02CA", "\u02CB", "\u02CC", "\u02CD", "\u02CE", "\u02CF", "\u02D0", "\u02D1", "\u02E0", "\u02E1", "\u02E2", "\u02E3", "\u02E4", "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", "\u06E5", "\u06E6", "\u07F4", "\u07F5", "\u07FA", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1C78", "\u1C79", "\u1C7A", "\u1C7B", "\u1C7C", "\u1C7D", "\u1D2C", "\u1D2D", "\u1D2E", "\u1D2F", "\u1D30", "\u1D31", "\u1D32", "\u1D33", "\u1D34", "\u1D35", "\u1D36", "\u1D37", "\u1D38", "\u1D39", "\u1D3A", "\u1D3B", "\u1D3C", "\u1D3D", "\u1D3E", "\u1D3F", "\u1D40", "\u1D41", "\u1D42", "\u1D43", "\u1D44", "\u1D45", "\u1D46", "\u1D47", "\u1D48", "\u1D49", "\u1D4A", "\u1D4B", "\u1D4C", "\u1D4D", "\u1D4E", "\u1D4F", "\u1D50", "\u1D51", "\u1D52", "\u1D53", "\u1D54", "\u1D55", "\u1D56", "\u1D57", "\u1D58", "\u1D59", "\u1D5A", "\u1D5B", "\u1D5C", "\u1D5D", "\u1D5E", "\u1D5F", "\u1D60", "\u1D61", "\u1D78", "\u1D9B", "\u1D9C", "\u1D9D", "\u1D9E", "\u1D9F", "\u1DA0", "\u1DA1", "\u1DA2", "\u1DA3", "\u1DA4", "\u1DA5", "\u1DA6", "\u1DA7", "\u1DA8", "\u1DA9", "\u1DAA", "\u1DAB", "\u1DAC", "\u1DAD", "\u1DAE", "\u1DAF", "\u1DB0", "\u1DB1", "\u1DB2", "\u1DB3", "\u1DB4", "\u1DB5", "\u1DB6", "\u1DB7", "\u1DB8", "\u1DB9", "\u1DBA", "\u1DBB", "\u1DBC", "\u1DBD", "\u1DBE", "\u1DBF", "\u2090", "\u2091", "\u2092", "\u2093", "\u2094", "\u2C7D", "\u2D6F", "\u2E2F", "\u3005", "\u3031", "\u3032", "\u3033", "\u3034", "\u3035", "\u303B", "\u309D", "\u309E", "\u30FC", "\u30FD", "\u30FE", "\uA015", "\uA60C", "\uA67F", "\uA717", "\uA718", "\uA719", "\uA71A", "\uA71B", "\uA71C", "\uA71D", "\uA71E", "\uA71F", "\uA770", "\uA788", "\uFF70", "\uFF9E", "\uFF9F"], false, false),
+      peg$c257 = peg$otherExpectation("Unicode other letter"),
+      peg$c258 = /^[\u01BB\u01C0\u01C1\u01C2\u01C3\u0294\u05D0\u05D1\u05D2\u05D3\u05D4\u05D5\u05D6\u05D7\u05D8\u05D9\u05DA\u05DB\u05DC\u05DD\u05DE\u05DF\u05E0\u05E1\u05E2\u05E3\u05E4\u05E5\u05E6\u05E7\u05E8\u05E9\u05EA\u05F0\u05F1\u05F2\u0621\u0622\u0623\u0624\u0625\u0626\u0627\u0628\u0629\u062A\u062B\u062C\u062D\u062E\u062F\u0630\u0631\u0632\u0633\u0634\u0635\u0636\u0637\u0638\u0639\u063A\u063B\u063C\u063D\u063E\u063F\u0641\u0642\u0643\u0644\u0645\u0646\u0647\u0648\u0649\u064A\u066E\u066F\u0671\u0672\u0673\u0674\u0675\u0676\u0677\u0678\u0679\u067A\u067B\u067C\u067D\u067E\u067F\u0680\u0681\u0682\u0683\u0684\u0685\u0686\u0687\u0688\u0689\u068A\u068B\u068C\u068D\u068E\u068F\u0690\u0691\u0692\u0693\u0694\u0695\u0696\u0697\u0698\u0699\u069A\u069B\u069C\u069D\u069E\u069F\u06A0\u06A1\u06A2\u06A3\u06A4\u06A5\u06A6\u06A7\u06A8\u06A9\u06AA\u06AB\u06AC\u06AD\u06AE\u06AF\u06B0\u06B1\u06B2\u06B3\u06B4\u06B5\u06B6\u06B7\u06B8\u06B9\u06BA\u06BB\u06BC\u06BD\u06BE\u06BF\u06C0\u06C1\u06C2\u06C3\u06C4\u06C5\u06C6\u06C7\u06C8\u06C9\u06CA\u06CB\u06CC\u06CD\u06CE\u06CF\u06D0\u06D1\u06D2\u06D3\u06D5\u06EE\u06EF\u06FA\u06FB\u06FC\u06FF\u0710\u0712\u0713\u0714\u0715\u0716\u0717\u0718\u0719\u071A\u071B\u071C\u071D\u071E\u071F\u0720\u0721\u0722\u0723\u0724\u0725\u0726\u0727\u0728\u0729\u072A\u072B\u072C\u072D\u072E\u072F\u074D\u074E\u074F\u0750\u0751\u0752\u0753\u0754\u0755\u0756\u0757\u0758\u0759\u075A\u075B\u075C\u075D\u075E\u075F\u0760\u0761\u0762\u0763\u0764\u0765\u0766\u0767\u0768\u0769\u076A\u076B\u076C\u076D\u076E\u076F\u0770\u0771\u0772\u0773\u0774\u0775\u0776\u0777\u0778\u0779\u077A\u077B\u077C\u077D\u077E\u077F\u0780\u0781\u0782\u0783\u0784\u0785\u0786\u0787\u0788\u0789\u078A\u078B\u078C\u078D\u078E\u078F\u0790\u0791\u0792\u0793\u0794\u0795\u0796\u0797\u0798\u0799\u079A\u079B\u079C\u079D\u079E\u079F\u07A0\u07A1\u07A2\u07A3\u07A4\u07A5\u07B1\u07CA\u07CB\u07CC\u07CD\u07CE\u07CF\u07D0\u07D1\u07D2\u07D3\u07D4\u07D5\u07D6\u07D7\u07D8\u07D9\u07DA\u07DB\u07DC\u07DD\u07DE\u07DF\u07E0\u07E1\u07E2\u07E3\u07E4\u07E5\u07E6\u07E7\u07E8\u07E9\u07EA\u0904\u0905\u0906\u0907\u0908\u0909\u090A\u090B\u090C\u090D\u090E\u090F\u0910\u0911\u0912\u0913\u0914\u0915\u0916\u0917\u0918\u0919\u091A\u091B\u091C\u091D\u091E\u091F\u0920\u0921\u0922\u0923\u0924\u0925\u0926\u0927\u0928\u0929\u092A\u092B\u092C\u092D\u092E\u092F\u0930\u0931\u0932\u0933\u0934\u0935\u0936\u0937\u0938\u0939\u093D\u0950\u0958\u0959\u095A\u095B\u095C\u095D\u095E\u095F\u0960\u0961\u0972\u097B\u097C\u097D\u097E\u097F\u0985\u0986\u0987\u0988\u0989\u098A\u098B\u098C\u098F\u0990\u0993\u0994\u0995\u0996\u0997\u0998\u0999\u099A\u099B\u099C\u099D\u099E\u099F\u09A0\u09A1\u09A2\u09A3\u09A4\u09A5\u09A6\u09A7\u09A8\u09AA\u09AB\u09AC\u09AD\u09AE\u09AF\u09B0\u09B2\u09B6\u09B7\u09B8\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF\u09E0\u09E1\u09F0\u09F1\u0A05\u0A06\u0A07\u0A08\u0A09\u0A0A\u0A0F\u0A10\u0A13\u0A14\u0A15\u0A16\u0A17\u0A18\u0A19\u0A1A\u0A1B\u0A1C\u0A1D\u0A1E\u0A1F\u0A20\u0A21\u0A22\u0A23\u0A24\u0A25\u0A26\u0A27\u0A28\u0A2A\u0A2B\u0A2C\u0A2D\u0A2E\u0A2F\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59\u0A5A\u0A5B\u0A5C\u0A5E\u0A72\u0A73\u0A74\u0A85\u0A86\u0A87\u0A88\u0A89\u0A8A\u0A8B\u0A8C\u0A8D\u0A8F\u0A90\u0A91\u0A93\u0A94\u0A95\u0A96\u0A97\u0A98\u0A99\u0A9A\u0A9B\u0A9C\u0A9D\u0A9E\u0A9F\u0AA0\u0AA1\u0AA2\u0AA3\u0AA4\u0AA5\u0AA6\u0AA7\u0AA8\u0AAA\u0AAB\u0AAC\u0AAD\u0AAE\u0AAF\u0AB0\u0AB2\u0AB3\u0AB5\u0AB6\u0AB7\u0AB8\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0B05\u0B06\u0B07\u0B08\u0B09\u0B0A\u0B0B\u0B0C\u0B0F\u0B10\u0B13\u0B14\u0B15\u0B16\u0B17\u0B18\u0B19\u0B1A\u0B1B\u0B1C\u0B1D\u0B1E\u0B1F\u0B20\u0B21\u0B22\u0B23\u0B24\u0B25\u0B26\u0B27\u0B28\u0B2A\u0B2B\u0B2C\u0B2D\u0B2E\u0B2F\u0B30\u0B32\u0B33\u0B35\u0B36\u0B37\u0B38\u0B39\u0B3D\u0B5C\u0B5D\u0B5F\u0B60\u0B61\u0B71\u0B83\u0B85\u0B86\u0B87\u0B88\u0B89\u0B8A\u0B8E\u0B8F\u0B90\u0B92\u0B93\u0B94\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8\u0BA9\u0BAA\u0BAE\u0BAF\u0BB0\u0BB1\u0BB2\u0BB3\u0BB4\u0BB5\u0BB6\u0BB7\u0BB8\u0BB9\u0BD0\u0C05\u0C06\u0C07\u0C08\u0C09\u0C0A\u0C0B\u0C0C\u0C0E\u0C0F\u0C10\u0C12\u0C13\u0C14\u0C15\u0C16\u0C17\u0C18\u0C19\u0C1A\u0C1B\u0C1C\u0C1D\u0C1E\u0C1F\u0C20\u0C21\u0C22\u0C23\u0C24\u0C25\u0C26\u0C27\u0C28\u0C2A\u0C2B\u0C2C\u0C2D\u0C2E\u0C2F\u0C30\u0C31\u0C32\u0C33\u0C35\u0C36\u0C37\u0C38\u0C39\u0C3D\u0C58\u0C59\u0C60\u0C61\u0C85\u0C86\u0C87\u0C88\u0C89\u0C8A\u0C8B\u0C8C\u0C8E\u0C8F\u0C90\u0C92\u0C93\u0C94\u0C95\u0C96\u0C97\u0C98\u0C99\u0C9A\u0C9B\u0C9C\u0C9D\u0C9E\u0C9F\u0CA0\u0CA1\u0CA2\u0CA3\u0CA4\u0CA5\u0CA6\u0CA7\u0CA8\u0CAA\u0CAB\u0CAC\u0CAD\u0CAE\u0CAF\u0CB0\u0CB1\u0CB2\u0CB3\u0CB5\u0CB6\u0CB7\u0CB8\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0D05\u0D06\u0D07\u0D08\u0D09\u0D0A\u0D0B\u0D0C\u0D0E\u0D0F\u0D10\u0D12\u0D13\u0D14\u0D15\u0D16\u0D17\u0D18\u0D19\u0D1A\u0D1B\u0D1C\u0D1D\u0D1E\u0D1F\u0D20\u0D21\u0D22\u0D23\u0D24\u0D25\u0D26\u0D27\u0D28\u0D2A\u0D2B\u0D2C\u0D2D\u0D2E\u0D2F\u0D30\u0D31\u0D32\u0D33\u0D34\u0D35\u0D36\u0D37\u0D38\u0D39\u0D3D\u0D60\u0D61\u0D7A\u0D7B\u0D7C\u0D7D\u0D7E\u0D7F\u0D85\u0D86\u0D87\u0D88\u0D89\u0D8A\u0D8B\u0D8C\u0D8D\u0D8E\u0D8F\u0D90\u0D91\u0D92\u0D93\u0D94\u0D95\u0D96\u0D9A\u0D9B\u0D9C\u0D9D\u0D9E\u0D9F\u0DA0\u0DA1\u0DA2\u0DA3\u0DA4\u0DA5\u0DA6\u0DA7\u0DA8\u0DA9\u0DAA\u0DAB\u0DAC\u0DAD\u0DAE\u0DAF\u0DB0\u0DB1\u0DB3\u0DB4\u0DB5\u0DB6\u0DB7\u0DB8\u0DB9\u0DBA\u0DBB\u0DBD\u0DC0\u0DC1\u0DC2\u0DC3\u0DC4\u0DC5\u0DC6\u0E01\u0E02\u0E03\u0E04\u0E05\u0E06\u0E07\u0E08\u0E09\u0E0A\u0E0B\u0E0C\u0E0D\u0E0E\u0E0F\u0E10\u0E11\u0E12\u0E13\u0E14\u0E15\u0E16\u0E17\u0E18\u0E19\u0E1A\u0E1B\u0E1C\u0E1D\u0E1E\u0E1F\u0E20\u0E21\u0E22\u0E23\u0E24\u0E25\u0E26\u0E27\u0E28\u0E29\u0E2A\u0E2B\u0E2C\u0E2D\u0E2E\u0E2F\u0E30\u0E32\u0E33\u0E40\u0E41\u0E42\u0E43\u0E44\u0E45\u0E81\u0E82\u0E84\u0E87\u0E88\u0E8A\u0E8D\u0E94\u0E95\u0E96\u0E97\u0E99\u0E9A\u0E9B\u0E9C\u0E9D\u0E9E\u0E9F\u0EA1\u0EA2\u0EA3\u0EA5\u0EA7\u0EAA\u0EAB\u0EAD\u0EAE\u0EAF\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0\u0EC1\u0EC2\u0EC3\u0EC4\u0EDC\u0EDD\u0F00\u0F40\u0F41\u0F42\u0F43\u0F44\u0F45\u0F46\u0F47\u0F49\u0F4A\u0F4B\u0F4C\u0F4D\u0F4E\u0F4F\u0F50\u0F51\u0F52\u0F53\u0F54\u0F55\u0F56\u0F57\u0F58\u0F59\u0F5A\u0F5B\u0F5C\u0F5D\u0F5E\u0F5F\u0F60\u0F61\u0F62\u0F63\u0F64\u0F65\u0F66\u0F67\u0F68\u0F69\u0F6A\u0F6B\u0F6C\u0F88\u0F89\u0F8A\u0F8B\u1000\u1001\u1002\u1003\u1004\u1005\u1006\u1007\u1008\u1009\u100A\u100B\u100C\u100D\u100E\u100F\u1010\u1011\u1012\u1013\u1014\u1015\u1016\u1017\u1018\u1019\u101A\u101B\u101C\u101D\u101E\u101F\u1020\u1021\u1022\u1023\u1024\u1025\u1026\u1027\u1028\u1029\u102A\u103F\u1050\u1051\u1052\u1053\u1054\u1055\u105A\u105B\u105C\u105D\u1061\u1065\u1066\u106E\u106F\u1070\u1075\u1076\u1077\u1078\u1079\u107A\u107B\u107C\u107D\u107E\u107F\u1080\u1081\u108E\u10D0\u10D1\u10D2\u10D3\u10D4\u10D5\u10D6\u10D7\u10D8\u10D9\u10DA\u10DB\u10DC\u10DD\u10DE\u10DF\u10E0\u10E1\u10E2\u10E3\u10E4\u10E5\u10E6\u10E7\u10E8\u10E9\u10EA\u10EB\u10EC\u10ED\u10EE\u10EF\u10F0\u10F1\u10F2\u10F3\u10F4\u10F5\u10F6\u10F7\u10F8\u10F9\u10FA\u1100\u1101\u1102\u1103\u1104\u1105\u1106\u1107\u1108\u1109\u110A\u110B\u110C\u110D\u110E\u110F\u1110\u1111\u1112\u1113\u1114\u1115\u1116\u1117\u1118\u1119\u111A\u111B\u111C\u111D\u111E\u111F\u1120\u1121\u1122\u1123\u1124\u1125\u1126\u1127\u1128\u1129\u112A\u112B\u112C\u112D\u112E\u112F\u1130\u1131\u1132\u1133\u1134\u1135\u1136\u1137\u1138\u1139\u113A\u113B\u113C\u113D\u113E\u113F\u1140\u1141\u1142\u1143\u1144\u1145\u1146\u1147\u1148\u1149\u114A\u114B\u114C\u114D\u114E\u114F\u1150\u1151\u1152\u1153\u1154\u1155\u1156\u1157\u1158\u1159\u115F\u1160\u1161\u1162\u1163\u1164\u1165\u1166\u1167\u1168\u1169\u116A\u116B\u116C\u116D\u116E\u116F\u1170\u1171\u1172\u1173\u1174\u1175\u1176\u1177\u1178\u1179\u117A\u117B\u117C\u117D\u117E\u117F\u1180\u1181\u1182\u1183\u1184\u1185\u1186\u1187\u1188\u1189\u118A\u118B\u118C\u118D\u118E\u118F\u1190\u1191\u1192\u1193\u1194\u1195\u1196\u1197\u1198\u1199\u119A\u119B\u119C\u119D\u119E\u119F\u11A0\u11A1\u11A2\u11A8\u11A9\u11AA\u11AB\u11AC\u11AD\u11AE\u11AF\u11B0\u11B1\u11B2\u11B3\u11B4\u11B5\u11B6\u11B7\u11B8\u11B9\u11BA\u11BB\u11BC\u11BD\u11BE\u11BF\u11C0\u11C1\u11C2\u11C3\u11C4\u11C5\u11C6\u11C7\u11C8\u11C9\u11CA\u11CB\u11CC\u11CD\u11CE\u11CF\u11D0\u11D1\u11D2\u11D3\u11D4\u11D5\u11D6\u11D7\u11D8\u11D9\u11DA\u11DB\u11DC\u11DD\u11DE\u11DF\u11E0\u11E1\u11E2\u11E3\u11E4\u11E5\u11E6\u11E7\u11E8\u11E9\u11EA\u11EB\u11EC\u11ED\u11EE\u11EF\u11F0\u11F1\u11F2\u11F3\u11F4\u11F5\u11F6\u11F7\u11F8\u11F9\u1200\u1201\u1202\u1203\u1204\u1205\u1206\u1207\u1208\u1209\u120A\u120B\u120C\u120D\u120E\u120F\u1210\u1211\u1212\u1213\u1214\u1215\u1216\u1217\u1218\u1219\u121A\u121B\u121C\u121D\u121E\u121F\u1220\u1221\u1222\u1223\u1224\u1225\u1226\u1227\u1228\u1229\u122A\u122B\u122C\u122D\u122E\u122F\u1230\u1231\u1232\u1233\u1234\u1235\u1236\u1237\u1238\u1239\u123A\u123B\u123C\u123D\u123E\u123F\u1240\u1241\u1242\u1243\u1244\u1245\u1246\u1247\u1248\u124A\u124B\u124C\u124D\u1250\u1251\u1252\u1253\u1254\u1255\u1256\u1258\u125A\u125B\u125C\u125D\u1260\u1261\u1262\u1263\u1264\u1265\u1266\u1267\u1268\u1269\u126A\u126B\u126C\u126D\u126E\u126F\u1270\u1271\u1272\u1273\u1274\u1275\u1276\u1277\u1278\u1279\u127A\u127B\u127C\u127D\u127E\u127F\u1280\u1281\u1282\u1283\u1284\u1285\u1286\u1287\u1288\u128A\u128B\u128C\u128D\u1290\u1291\u1292\u1293\u1294\u1295\u1296\u1297\u1298\u1299\u129A\u129B\u129C\u129D\u129E\u129F\u12A0\u12A1\u12A2\u12A3\u12A4\u12A5\u12A6\u12A7\u12A8\u12A9\u12AA\u12AB\u12AC\u12AD\u12AE\u12AF\u12B0\u12B2\u12B3\u12B4\u12B5\u12B8\u12B9\u12BA\u12BB\u12BC\u12BD\u12BE\u12C0\u12C2\u12C3\u12C4\u12C5\u12C8\u12C9\u12CA\u12CB\u12CC\u12CD\u12CE\u12CF\u12D0\u12D1\u12D2\u12D3\u12D4\u12D5\u12D6\u12D8\u12D9\u12DA\u12DB\u12DC\u12DD\u12DE\u12DF\u12E0\u12E1\u12E2\u12E3\u12E4\u12E5\u12E6\u12E7\u12E8\u12E9\u12EA\u12EB\u12EC\u12ED\u12EE\u12EF\u12F0\u12F1\u12F2\u12F3\u12F4\u12F5\u12F6\u12F7\u12F8\u12F9\u12FA\u12FB\u12FC\u12FD\u12FE\u12FF\u1300\u1301\u1302\u1303\u1304\u1305\u1306\u1307\u1308\u1309\u130A\u130B\u130C\u130D\u130E\u130F\u1310\u1312\u1313\u1314\u1315\u1318\u1319\u131A\u131B\u131C\u131D\u131E\u131F\u1320\u1321\u1322\u1323\u1324\u1325\u1326\u1327\u1328\u1329\u132A\u132B\u132C\u132D\u132E\u132F\u1330\u1331\u1332\u1333\u1334\u1335\u1336\u1337\u1338\u1339\u133A\u133B\u133C\u133D\u133E\u133F\u1340\u1341\u1342\u1343\u1344\u1345\u1346\u1347\u1348\u1349\u134A\u134B\u134C\u134D\u134E\u134F\u1350\u1351\u1352\u1353\u1354\u1355\u1356\u1357\u1358\u1359\u135A\u1380\u1381\u1382\u1383\u1384\u1385\u1386\u1387\u1388\u1389\u138A\u138B\u138C\u138D\u138E\u138F\u13A0\u13A1\u13A2\u13A3\u13A4\u13A5\u13A6\u13A7\u13A8\u13A9\u13AA\u13AB\u13AC\u13AD\u13AE\u13AF\u13B0\u13B1\u13B2\u13B3\u13B4\u13B5\u13B6\u13B7\u13B8\u13B9\u13BA\u13BB\u13BC\u13BD\u13BE\u13BF\u13C0\u13C1\u13C2\u13C3\u13C4\u13C5\u13C6\u13C7\u13C8\u13C9\u13CA\u13CB\u13CC\u13CD\u13CE\u13CF\u13D0\u13D1\u13D2\u13D3\u13D4\u13D5\u13D6\u13D7\u13D8\u13D9\u13DA\u13DB\u13DC\u13DD\u13DE\u13DF\u13E0\u13E1\u13E2\u13E3\u13E4\u13E5\u13E6\u13E7\u13E8\u13E9\u13EA\u13EB\u13EC\u13ED\u13EE\u13EF\u13F0\u13F1\u13F2\u13F3\u13F4\u1401\u1402\u1403\u1404\u1405\u1406\u1407\u1408\u1409\u140A\u140B\u140C\u140D\u140E\u140F\u1410\u1411\u1412\u1413\u1414\u1415\u1416\u1417\u1418\u1419\u141A\u141B\u141C\u141D\u141E\u141F\u1420\u1421\u1422\u1423\u1424\u1425\u1426\u1427\u1428\u1429\u142A\u142B\u142C\u142D\u142E\u142F\u1430\u1431\u1432\u1433\u1434\u1435\u1436\u1437\u1438\u1439\u143A\u143B\u143C\u143D\u143E\u143F\u1440\u1441\u1442\u1443\u1444\u1445\u1446\u1447\u1448\u1449\u144A\u144B\u144C\u144D\u144E\u144F\u1450\u1451\u1452\u1453\u1454\u1455\u1456\u1457\u1458\u1459\u145A\u145B\u145C\u145D\u145E\u145F\u1460\u1461\u1462\u1463\u1464\u1465\u1466\u1467\u1468\u1469\u146A\u146B\u146C\u146D\u146E\u146F\u1470\u1471\u1472\u1473\u1474\u1475\u1476\u1477\u1478\u1479\u147A\u147B\u147C\u147D\u147E\u147F\u1480\u1481\u1482\u1483\u1484\u1485\u1486\u1487\u1488\u1489\u148A\u148B\u148C\u148D\u148E\u148F\u1490\u1491\u1492\u1493\u1494\u1495\u1496\u1497\u1498\u1499\u149A\u149B\u149C\u149D\u149E\u149F\u14A0\u14A1\u14A2\u14A3\u14A4\u14A5\u14A6\u14A7\u14A8\u14A9\u14AA\u14AB\u14AC\u14AD\u14AE\u14AF\u14B0\u14B1\u14B2\u14B3\u14B4\u14B5\u14B6\u14B7\u14B8\u14B9\u14BA\u14BB\u14BC\u14BD\u14BE\u14BF\u14C0\u14C1\u14C2\u14C3\u14C4\u14C5\u14C6\u14C7\u14C8\u14C9\u14CA\u14CB\u14CC\u14CD\u14CE\u14CF\u14D0\u14D1\u14D2\u14D3\u14D4\u14D5\u14D6\u14D7\u14D8\u14D9\u14DA\u14DB\u14DC\u14DD\u14DE\u14DF\u14E0\u14E1\u14E2\u14E3\u14E4\u14E5\u14E6\u14E7\u14E8\u14E9\u14EA\u14EB\u14EC\u14ED\u14EE\u14EF\u14F0\u14F1\u14F2\u14F3\u14F4\u14F5\u14F6\u14F7\u14F8\u14F9\u14FA\u14FB\u14FC\u14FD\u14FE\u14FF\u1500\u1501\u1502\u1503\u1504\u1505\u1506\u1507\u1508\u1509\u150A\u150B\u150C\u150D\u150E\u150F\u1510\u1511\u1512\u1513\u1514\u1515\u1516\u1517\u1518\u1519\u151A\u151B\u151C\u151D\u151E\u151F\u1520\u1521\u1522\u1523\u1524\u1525\u1526\u1527\u1528\u1529\u152A\u152B\u152C\u152D\u152E\u152F\u1530\u1531\u1532\u1533\u1534\u1535\u1536\u1537\u1538\u1539\u153A\u153B\u153C\u153D\u153E\u153F\u1540\u1541\u1542\u1543\u1544\u1545\u1546\u1547\u1548\u1549\u154A\u154B\u154C\u154D\u154E\u154F\u1550\u1551\u1552\u1553\u1554\u1555\u1556\u1557\u1558\u1559\u155A\u155B\u155C\u155D\u155E\u155F\u1560\u1561\u1562\u1563\u1564\u1565\u1566\u1567\u1568\u1569\u156A\u156B\u156C\u156D\u156E\u156F\u1570\u1571\u1572\u1573\u1574\u1575\u1576\u1577\u1578\u1579\u157A\u157B\u157C\u157D\u157E\u157F\u1580\u1581\u1582\u1583\u1584\u1585\u1586\u1587\u1588\u1589\u158A\u158B\u158C\u158D\u158E\u158F\u1590\u1591\u1592\u1593\u1594\u1595\u1596\u1597\u1598\u1599\u159A\u159B\u159C\u159D\u159E\u159F\u15A0\u15A1\u15A2\u15A3\u15A4\u15A5\u15A6\u15A7\u15A8\u15A9\u15AA\u15AB\u15AC\u15AD\u15AE\u15AF\u15B0\u15B1\u15B2\u15B3\u15B4\u15B5\u15B6\u15B7\u15B8\u15B9\u15BA\u15BB\u15BC\u15BD\u15BE\u15BF\u15C0\u15C1\u15C2\u15C3\u15C4\u15C5\u15C6\u15C7\u15C8\u15C9\u15CA\u15CB\u15CC\u15CD\u15CE\u15CF\u15D0\u15D1\u15D2\u15D3\u15D4\u15D5\u15D6\u15D7\u15D8\u15D9\u15DA\u15DB\u15DC\u15DD\u15DE\u15DF\u15E0\u15E1\u15E2\u15E3\u15E4\u15E5\u15E6\u15E7\u15E8\u15E9\u15EA\u15EB\u15EC\u15ED\u15EE\u15EF\u15F0\u15F1\u15F2\u15F3\u15F4\u15F5\u15F6\u15F7\u15F8\u15F9\u15FA\u15FB\u15FC\u15FD\u15FE\u15FF\u1600\u1601\u1602\u1603\u1604\u1605\u1606\u1607\u1608\u1609\u160A\u160B\u160C\u160D\u160E\u160F\u1610\u1611\u1612\u1613\u1614\u1615\u1616\u1617\u1618\u1619\u161A\u161B\u161C\u161D\u161E\u161F\u1620\u1621\u1622\u1623\u1624\u1625\u1626\u1627\u1628\u1629\u162A\u162B\u162C\u162D\u162E\u162F\u1630\u1631\u1632\u1633\u1634\u1635\u1636\u1637\u1638\u1639\u163A\u163B\u163C\u163D\u163E\u163F\u1640\u1641\u1642\u1643\u1644\u1645\u1646\u1647\u1648\u1649\u164A\u164B\u164C\u164D\u164E\u164F\u1650\u1651\u1652\u1653\u1654\u1655\u1656\u1657\u1658\u1659\u165A\u165B\u165C\u165D\u165E\u165F\u1660\u1661\u1662\u1663\u1664\u1665\u1666\u1667\u1668\u1669\u166A\u166B\u166C\u166F\u1670\u1671\u1672\u1673\u1674\u1675\u1676\u1681\u1682\u1683\u1684\u1685\u1686\u1687\u1688\u1689\u168A\u168B\u168C\u168D\u168E\u168F\u1690\u1691\u1692\u1693\u1694\u1695\u1696\u1697\u1698\u1699\u169A\u16A0\u16A1\u16A2\u16A3\u16A4\u16A5\u16A6\u16A7\u16A8\u16A9\u16AA\u16AB\u16AC\u16AD\u16AE\u16AF\u16B0\u16B1\u16B2\u16B3\u16B4\u16B5\u16B6\u16B7\u16B8\u16B9\u16BA\u16BB\u16BC\u16BD\u16BE\u16BF\u16C0\u16C1\u16C2\u16C3\u16C4\u16C5\u16C6\u16C7\u16C8\u16C9\u16CA\u16CB\u16CC\u16CD\u16CE\u16CF\u16D0\u16D1\u16D2\u16D3\u16D4\u16D5\u16D6\u16D7\u16D8\u16D9\u16DA\u16DB\u16DC\u16DD\u16DE\u16DF\u16E0\u16E1\u16E2\u16E3\u16E4\u16E5\u16E6\u16E7\u16E8\u16E9\u16EA\u1700\u1701\u1702\u1703\u1704\u1705\u1706\u1707\u1708\u1709\u170A\u170B\u170C\u170E\u170F\u1710\u1711\u1720\u1721\u1722\u1723\u1724\u1725\u1726\u1727\u1728\u1729\u172A\u172B\u172C\u172D\u172E\u172F\u1730\u1731\u1740\u1741\u1742\u1743\u1744\u1745\u1746\u1747\u1748\u1749\u174A\u174B\u174C\u174D\u174E\u174F\u1750\u1751\u1760\u1761\u1762\u1763\u1764\u1765\u1766\u1767\u1768\u1769\u176A\u176B\u176C\u176E\u176F\u1770\u1780\u1781\u1782\u1783\u1784\u1785\u1786\u1787\u1788\u1789\u178A\u178B\u178C\u178D\u178E\u178F\u1790\u1791\u1792\u1793\u1794\u1795\u1796\u1797\u1798\u1799\u179A\u179B\u179C\u179D\u179E\u179F\u17A0\u17A1\u17A2\u17A3\u17A4\u17A5\u17A6\u17A7\u17A8\u17A9\u17AA\u17AB\u17AC\u17AD\u17AE\u17AF\u17B0\u17B1\u17B2\u17B3\u17DC\u1820\u1821\u1822\u1823\u1824\u1825\u1826\u1827\u1828\u1829\u182A\u182B\u182C\u182D\u182E\u182F\u1830\u1831\u1832\u1833\u1834\u1835\u1836\u1837\u1838\u1839\u183A\u183B\u183C\u183D\u183E\u183F\u1840\u1841\u1842\u1844\u1845\u1846\u1847\u1848\u1849\u184A\u184B\u184C\u184D\u184E\u184F\u1850\u1851\u1852\u1853\u1854\u1855\u1856\u1857\u1858\u1859\u185A\u185B\u185C\u185D\u185E\u185F\u1860\u1861\u1862\u1863\u1864\u1865\u1866\u1867\u1868\u1869\u186A\u186B\u186C\u186D\u186E\u186F\u1870\u1871\u1872\u1873\u1874\u1875\u1876\u1877\u1880\u1881\u1882\u1883\u1884\u1885\u1886\u1887\u1888\u1889\u188A\u188B\u188C\u188D\u188E\u188F\u1890\u1891\u1892\u1893\u1894\u1895\u1896\u1897\u1898\u1899\u189A\u189B\u189C\u189D\u189E\u189F\u18A0\u18A1\u18A2\u18A3\u18A4\u18A5\u18A6\u18A7\u18A8\u18AA\u1900\u1901\u1902\u1903\u1904\u1905\u1906\u1907\u1908\u1909\u190A\u190B\u190C\u190D\u190E\u190F\u1910\u1911\u1912\u1913\u1914\u1915\u1916\u1917\u1918\u1919\u191A\u191B\u191C\u1950\u1951\u1952\u1953\u1954\u1955\u1956\u1957\u1958\u1959\u195A\u195B\u195C\u195D\u195E\u195F\u1960\u1961\u1962\u1963\u1964\u1965\u1966\u1967\u1968\u1969\u196A\u196B\u196C\u196D\u1970\u1971\u1972\u1973\u1974\u1980\u1981\u1982\u1983\u1984\u1985\u1986\u1987\u1988\u1989\u198A\u198B\u198C\u198D\u198E\u198F\u1990\u1991\u1992\u1993\u1994\u1995\u1996\u1997\u1998\u1999\u199A\u199B\u199C\u199D\u199E\u199F\u19A0\u19A1\u19A2\u19A3\u19A4\u19A5\u19A6\u19A7\u19A8\u19A9\u19C1\u19C2\u19C3\u19C4\u19C5\u19C6\u19C7\u1A00\u1A01\u1A02\u1A03\u1A04\u1A05\u1A06\u1A07\u1A08\u1A09\u1A0A\u1A0B\u1A0C\u1A0D\u1A0E\u1A0F\u1A10\u1A11\u1A12\u1A13\u1A14\u1A15\u1A16\u1B05\u1B06\u1B07\u1B08\u1B09\u1B0A\u1B0B\u1B0C\u1B0D\u1B0E\u1B0F\u1B10\u1B11\u1B12\u1B13\u1B14\u1B15\u1B16\u1B17\u1B18\u1B19\u1B1A\u1B1B\u1B1C\u1B1D\u1B1E\u1B1F\u1B20\u1B21\u1B22\u1B23\u1B24\u1B25\u1B26\u1B27\u1B28\u1B29\u1B2A\u1B2B\u1B2C\u1B2D\u1B2E\u1B2F\u1B30\u1B31\u1B32\u1B33\u1B45\u1B46\u1B47\u1B48\u1B49\u1B4A\u1B4B\u1B83\u1B84\u1B85\u1B86\u1B87\u1B88\u1B89\u1B8A\u1B8B\u1B8C\u1B8D\u1B8E\u1B8F\u1B90\u1B91\u1B92\u1B93\u1B94\u1B95\u1B96\u1B97\u1B98\u1B99\u1B9A\u1B9B\u1B9C\u1B9D\u1B9E\u1B9F\u1BA0\u1BAE\u1BAF\u1C00\u1C01\u1C02\u1C03\u1C04\u1C05\u1C06\u1C07\u1C08\u1C09\u1C0A\u1C0B\u1C0C\u1C0D\u1C0E\u1C0F\u1C10\u1C11\u1C12\u1C13\u1C14\u1C15\u1C16\u1C17\u1C18\u1C19\u1C1A\u1C1B\u1C1C\u1C1D\u1C1E\u1C1F\u1C20\u1C21\u1C22\u1C23\u1C4D\u1C4E\u1C4F\u1C5A\u1C5B\u1C5C\u1C5D\u1C5E\u1C5F\u1C60\u1C61\u1C62\u1C63\u1C64\u1C65\u1C66\u1C67\u1C68\u1C69\u1C6A\u1C6B\u1C6C\u1C6D\u1C6E\u1C6F\u1C70\u1C71\u1C72\u1C73\u1C74\u1C75\u1C76\u1C77\u2135\u2136\u2137\u2138\u2D30\u2D31\u2D32\u2D33\u2D34\u2D35\u2D36\u2D37\u2D38\u2D39\u2D3A\u2D3B\u2D3C\u2D3D\u2D3E\u2D3F\u2D40\u2D41\u2D42\u2D43\u2D44\u2D45\u2D46\u2D47\u2D48\u2D49\u2D4A\u2D4B\u2D4C\u2D4D\u2D4E\u2D4F\u2D50\u2D51\u2D52\u2D53\u2D54\u2D55\u2D56\u2D57\u2D58\u2D59\u2D5A\u2D5B\u2D5C\u2D5D\u2D5E\u2D5F\u2D60\u2D61\u2D62\u2D63\u2D64\u2D65\u2D80\u2D81\u2D82\u2D83\u2D84\u2D85\u2D86\u2D87\u2D88\u2D89\u2D8A\u2D8B\u2D8C\u2D8D\u2D8E\u2D8F\u2D90\u2D91\u2D92\u2D93\u2D94\u2D95\u2D96\u2DA0\u2DA1\u2DA2\u2DA3\u2DA4\u2DA5\u2DA6\u2DA8\u2DA9\u2DAA\u2DAB\u2DAC\u2DAD\u2DAE\u2DB0\u2DB1\u2DB2\u2DB3\u2DB4\u2DB5\u2DB6\u2DB8\u2DB9\u2DBA\u2DBB\u2DBC\u2DBD\u2DBE\u2DC0\u2DC1\u2DC2\u2DC3\u2DC4\u2DC5\u2DC6\u2DC8\u2DC9\u2DCA\u2DCB\u2DCC\u2DCD\u2DCE\u2DD0\u2DD1\u2DD2\u2DD3\u2DD4\u2DD5\u2DD6\u2DD8\u2DD9\u2DDA\u2DDB\u2DDC\u2DDD\u2DDE\u3006\u303C\u3041\u3042\u3043\u3044\u3045\u3046\u3047\u3048\u3049\u304A\u304B\u304C\u304D\u304E\u304F\u3050\u3051\u3052\u3053\u3054\u3055\u3056\u3057\u3058\u3059\u305A\u305B\u305C\u305D\u305E\u305F\u3060\u3061\u3062\u3063\u3064\u3065\u3066\u3067\u3068\u3069\u306A\u306B\u306C\u306D\u306E\u306F\u3070\u3071\u3072\u3073\u3074\u3075\u3076\u3077\u3078\u3079\u307A\u307B\u307C\u307D\u307E\u307F\u3080\u3081\u3082\u3083\u3084\u3085\u3086\u3087\u3088\u3089\u308A\u308B\u308C\u308D\u308E\u308F\u3090\u3091\u3092\u3093\u3094\u3095\u3096\u309F\u30A1\u30A2\u30A3\u30A4\u30A5\u30A6\u30A7\u30A8\u30A9\u30AA\u30AB\u30AC\u30AD\u30AE\u30AF\u30B0\u30B1\u30B2\u30B3\u30B4\u30B5\u30B6\u30B7\u30B8\u30B9\u30BA\u30BB\u30BC\u30BD\u30BE\u30BF\u30C0\u30C1\u30C2\u30C3\u30C4\u30C5\u30C6\u30C7\u30C8\u30C9\u30CA\u30CB\u30CC\u30CD\u30CE\u30CF\u30D0\u30D1\u30D2\u30D3\u30D4\u30D5\u30D6\u30D7\u30D8\u30D9\u30DA\u30DB\u30DC\u30DD\u30DE\u30DF\u30E0\u30E1\u30E2\u30E3\u30E4\u30E5\u30E6\u30E7\u30E8\u30E9\u30EA\u30EB\u30EC\u30ED\u30EE\u30EF\u30F0\u30F1\u30F2\u30F3\u30F4\u30F5\u30F6\u30F7\u30F8\u30F9\u30FA\u30FF\u3105\u3106\u3107\u3108\u3109\u310A\u310B\u310C\u310D\u310E\u310F\u3110\u3111\u3112\u3113\u3114\u3115\u3116\u3117\u3118\u3119\u311A\u311B\u311C\u311D\u311E\u311F\u3120\u3121\u3122\u3123\u3124\u3125\u3126\u3127\u3128\u3129\u312A\u312B\u312C\u312D\u3131\u3132\u3133\u3134\u3135\u3136\u3137\u3138\u3139\u313A\u313B\u313C\u313D\u313E\u313F\u3140\u3141\u3142\u3143\u3144\u3145\u3146\u3147\u3148\u3149\u314A\u314B\u314C\u314D\u314E\u314F\u3150\u3151\u3152\u3153\u3154\u3155\u3156\u3157\u3158\u3159\u315A\u315B\u315C\u315D\u315E\u315F\u3160\u3161\u3162\u3163\u3164\u3165\u3166\u3167\u3168\u3169\u316A\u316B\u316C\u316D\u316E\u316F\u3170\u3171\u3172\u3173\u3174\u3175\u3176\u3177\u3178\u3179\u317A\u317B\u317C\u317D\u317E\u317F\u3180\u3181\u3182\u3183\u3184\u3185\u3186\u3187\u3188\u3189\u318A\u318B\u318C\u318D\u318E\u31A0\u31A1\u31A2\u31A3\u31A4\u31A5\u31A6\u31A7\u31A8\u31A9\u31AA\u31AB\u31AC\u31AD\u31AE\u31AF\u31B0\u31B1\u31B2\u31B3\u31B4\u31B5\u31B6\u31B7\u31F0\u31F1\u31F2\u31F3\u31F4\u31F5\u31F6\u31F7\u31F8\u31F9\u31FA\u31FB\u31FC\u31FD\u31FE\u31FF\u3400\u4DB5\u4E00\u9FC3\uA000\uA001\uA002\uA003\uA004\uA005\uA006\uA007\uA008\uA009\uA00A\uA00B\uA00C\uA00D\uA00E\uA00F\uA010\uA011\uA012\uA013\uA014\uA016\uA017\uA018\uA019\uA01A\uA01B\uA01C\uA01D\uA01E\uA01F\uA020\uA021\uA022\uA023\uA024\uA025\uA026\uA027\uA028\uA029\uA02A\uA02B\uA02C\uA02D\uA02E\uA02F\uA030\uA031\uA032\uA033\uA034\uA035\uA036\uA037\uA038\uA039\uA03A\uA03B\uA03C\uA03D\uA03E\uA03F\uA040\uA041\uA042\uA043\uA044\uA045\uA046\uA047\uA048\uA049\uA04A\uA04B\uA04C\uA04D\uA04E\uA04F\uA050\uA051\uA052\uA053\uA054\uA055\uA056\uA057\uA058\uA059\uA05A\uA05B\uA05C\uA05D\uA05E\uA05F\uA060\uA061\uA062\uA063\uA064\uA065\uA066\uA067\uA068\uA069\uA06A\uA06B\uA06C\uA06D\uA06E\uA06F\uA070\uA071\uA072\uA073\uA074\uA075\uA076\uA077\uA078\uA079\uA07A\uA07B\uA07C\uA07D\uA07E\uA07F\uA080\uA081\uA082\uA083\uA084\uA085\uA086\uA087\uA088\uA089\uA08A\uA08B\uA08C\uA08D\uA08E\uA08F\uA090\uA091\uA092\uA093\uA094\uA095\uA096\uA097\uA098\uA099\uA09A\uA09B\uA09C\uA09D\uA09E\uA09F\uA0A0\uA0A1\uA0A2\uA0A3\uA0A4\uA0A5\uA0A6\uA0A7\uA0A8\uA0A9\uA0AA\uA0AB\uA0AC\uA0AD\uA0AE\uA0AF\uA0B0\uA0B1\uA0B2\uA0B3\uA0B4\uA0B5\uA0B6\uA0B7\uA0B8\uA0B9\uA0BA\uA0BB\uA0BC\uA0BD\uA0BE\uA0BF\uA0C0\uA0C1\uA0C2\uA0C3\uA0C4\uA0C5\uA0C6\uA0C7\uA0C8\uA0C9\uA0CA\uA0CB\uA0CC\uA0CD\uA0CE\uA0CF\uA0D0\uA0D1\uA0D2\uA0D3\uA0D4\uA0D5\uA0D6\uA0D7\uA0D8\uA0D9\uA0DA\uA0DB\uA0DC\uA0DD\uA0DE\uA0DF\uA0E0\uA0E1\uA0E2\uA0E3\uA0E4\uA0E5\uA0E6\uA0E7\uA0E8\uA0E9\uA0EA\uA0EB\uA0EC\uA0ED\uA0EE\uA0EF\uA0F0\uA0F1\uA0F2\uA0F3\uA0F4\uA0F5\uA0F6\uA0F7\uA0F8\uA0F9\uA0FA\uA0FB\uA0FC\uA0FD\uA0FE\uA0FF\uA100\uA101\uA102\uA103\uA104\uA105\uA106\uA107\uA108\uA109\uA10A\uA10B\uA10C\uA10D\uA10E\uA10F\uA110\uA111\uA112\uA113\uA114\uA115\uA116\uA117\uA118\uA119\uA11A\uA11B\uA11C\uA11D\uA11E\uA11F\uA120\uA121\uA122\uA123\uA124\uA125\uA126\uA127\uA128\uA129\uA12A\uA12B\uA12C\uA12D\uA12E\uA12F\uA130\uA131\uA132\uA133\uA134\uA135\uA136\uA137\uA138\uA139\uA13A\uA13B\uA13C\uA13D\uA13E\uA13F\uA140\uA141\uA142\uA143\uA144\uA145\uA146\uA147\uA148\uA149\uA14A\uA14B\uA14C\uA14D\uA14E\uA14F\uA150\uA151\uA152\uA153\uA154\uA155\uA156\uA157\uA158\uA159\uA15A\uA15B\uA15C\uA15D\uA15E\uA15F\uA160\uA161\uA162\uA163\uA164\uA165\uA166\uA167\uA168\uA169\uA16A\uA16B\uA16C\uA16D\uA16E\uA16F\uA170\uA171\uA172\uA173\uA174\uA175\uA176\uA177\uA178\uA179\uA17A\uA17B\uA17C\uA17D\uA17E\uA17F\uA180\uA181\uA182\uA183\uA184\uA185\uA186\uA187\uA188\uA189\uA18A\uA18B\uA18C\uA18D\uA18E\uA18F\uA190\uA191\uA192\uA193\uA194\uA195\uA196\uA197\uA198\uA199\uA19A\uA19B\uA19C\uA19D\uA19E\uA19F\uA1A0\uA1A1\uA1A2\uA1A3\uA1A4\uA1A5\uA1A6\uA1A7\uA1A8\uA1A9\uA1AA\uA1AB\uA1AC\uA1AD\uA1AE\uA1AF]/,
+      peg$c259 = peg$classExpectation(["\u01BB", "\u01C0", "\u01C1", "\u01C2", "\u01C3", "\u0294", "\u05D0", "\u05D1", "\u05D2", "\u05D3", "\u05D4", "\u05D5", "\u05D6", "\u05D7", "\u05D8", "\u05D9", "\u05DA", "\u05DB", "\u05DC", "\u05DD", "\u05DE", "\u05DF", "\u05E0", "\u05E1", "\u05E2", "\u05E3", "\u05E4", "\u05E5", "\u05E6", "\u05E7", "\u05E8", "\u05E9", "\u05EA", "\u05F0", "\u05F1", "\u05F2", "\u0621", "\u0622", "\u0623", "\u0624", "\u0625", "\u0626", "\u0627", "\u0628", "\u0629", "\u062A", "\u062B", "\u062C", "\u062D", "\u062E", "\u062F", "\u0630", "\u0631", "\u0632", "\u0633", "\u0634", "\u0635", "\u0636", "\u0637", "\u0638", "\u0639", "\u063A", "\u063B", "\u063C", "\u063D", "\u063E", "\u063F", "\u0641", "\u0642", "\u0643", "\u0644", "\u0645", "\u0646", "\u0647", "\u0648", "\u0649", "\u064A", "\u066E", "\u066F", "\u0671", "\u0672", "\u0673", "\u0674", "\u0675", "\u0676", "\u0677", "\u0678", "\u0679", "\u067A", "\u067B", "\u067C", "\u067D", "\u067E", "\u067F", "\u0680", "\u0681", "\u0682", "\u0683", "\u0684", "\u0685", "\u0686", "\u0687", "\u0688", "\u0689", "\u068A", "\u068B", "\u068C", "\u068D", "\u068E", "\u068F", "\u0690", "\u0691", "\u0692", "\u0693", "\u0694", "\u0695", "\u0696", "\u0697", "\u0698", "\u0699", "\u069A", "\u069B", "\u069C", "\u069D", "\u069E", "\u069F", "\u06A0", "\u06A1", "\u06A2", "\u06A3", "\u06A4", "\u06A5", "\u06A6", "\u06A7", "\u06A8", "\u06A9", "\u06AA", "\u06AB", "\u06AC", "\u06AD", "\u06AE", "\u06AF", "\u06B0", "\u06B1", "\u06B2", "\u06B3", "\u06B4", "\u06B5", "\u06B6", "\u06B7", "\u06B8", "\u06B9", "\u06BA", "\u06BB", "\u06BC", "\u06BD", "\u06BE", "\u06BF", "\u06C0", "\u06C1", "\u06C2", "\u06C3", "\u06C4", "\u06C5", "\u06C6", "\u06C7", "\u06C8", "\u06C9", "\u06CA", "\u06CB", "\u06CC", "\u06CD", "\u06CE", "\u06CF", "\u06D0", "\u06D1", "\u06D2", "\u06D3", "\u06D5", "\u06EE", "\u06EF", "\u06FA", "\u06FB", "\u06FC", "\u06FF", "\u0710", "\u0712", "\u0713", "\u0714", "\u0715", "\u0716", "\u0717", "\u0718", "\u0719", "\u071A", "\u071B", "\u071C", "\u071D", "\u071E", "\u071F", "\u0720", "\u0721", "\u0722", "\u0723", "\u0724", "\u0725", "\u0726", "\u0727", "\u0728", "\u0729", "\u072A", "\u072B", "\u072C", "\u072D", "\u072E", "\u072F", "\u074D", "\u074E", "\u074F", "\u0750", "\u0751", "\u0752", "\u0753", "\u0754", "\u0755", "\u0756", "\u0757", "\u0758", "\u0759", "\u075A", "\u075B", "\u075C", "\u075D", "\u075E", "\u075F", "\u0760", "\u0761", "\u0762", "\u0763", "\u0764", "\u0765", "\u0766", "\u0767", "\u0768", "\u0769", "\u076A", "\u076B", "\u076C", "\u076D", "\u076E", "\u076F", "\u0770", "\u0771", "\u0772", "\u0773", "\u0774", "\u0775", "\u0776", "\u0777", "\u0778", "\u0779", "\u077A", "\u077B", "\u077C", "\u077D", "\u077E", "\u077F", "\u0780", "\u0781", "\u0782", "\u0783", "\u0784", "\u0785", "\u0786", "\u0787", "\u0788", "\u0789", "\u078A", "\u078B", "\u078C", "\u078D", "\u078E", "\u078F", "\u0790", "\u0791", "\u0792", "\u0793", "\u0794", "\u0795", "\u0796", "\u0797", "\u0798", "\u0799", "\u079A", "\u079B", "\u079C", "\u079D", "\u079E", "\u079F", "\u07A0", "\u07A1", "\u07A2", "\u07A3", "\u07A4", "\u07A5", "\u07B1", "\u07CA", "\u07CB", "\u07CC", "\u07CD", "\u07CE", "\u07CF", "\u07D0", "\u07D1", "\u07D2", "\u07D3", "\u07D4", "\u07D5", "\u07D6", "\u07D7", "\u07D8", "\u07D9", "\u07DA", "\u07DB", "\u07DC", "\u07DD", "\u07DE", "\u07DF", "\u07E0", "\u07E1", "\u07E2", "\u07E3", "\u07E4", "\u07E5", "\u07E6", "\u07E7", "\u07E8", "\u07E9", "\u07EA", "\u0904", "\u0905", "\u0906", "\u0907", "\u0908", "\u0909", "\u090A", "\u090B", "\u090C", "\u090D", "\u090E", "\u090F", "\u0910", "\u0911", "\u0912", "\u0913", "\u0914", "\u0915", "\u0916", "\u0917", "\u0918", "\u0919", "\u091A", "\u091B", "\u091C", "\u091D", "\u091E", "\u091F", "\u0920", "\u0921", "\u0922", "\u0923", "\u0924", "\u0925", "\u0926", "\u0927", "\u0928", "\u0929", "\u092A", "\u092B", "\u092C", "\u092D", "\u092E", "\u092F", "\u0930", "\u0931", "\u0932", "\u0933", "\u0934", "\u0935", "\u0936", "\u0937", "\u0938", "\u0939", "\u093D", "\u0950", "\u0958", "\u0959", "\u095A", "\u095B", "\u095C", "\u095D", "\u095E", "\u095F", "\u0960", "\u0961", "\u0972", "\u097B", "\u097C", "\u097D", "\u097E", "\u097F", "\u0985", "\u0986", "\u0987", "\u0988", "\u0989", "\u098A", "\u098B", "\u098C", "\u098F", "\u0990", "\u0993", "\u0994", "\u0995", "\u0996", "\u0997", "\u0998", "\u0999", "\u099A", "\u099B", "\u099C", "\u099D", "\u099E", "\u099F", "\u09A0", "\u09A1", "\u09A2", "\u09A3", "\u09A4", "\u09A5", "\u09A6", "\u09A7", "\u09A8", "\u09AA", "\u09AB", "\u09AC", "\u09AD", "\u09AE", "\u09AF", "\u09B0", "\u09B2", "\u09B6", "\u09B7", "\u09B8", "\u09B9", "\u09BD", "\u09CE", "\u09DC", "\u09DD", "\u09DF", "\u09E0", "\u09E1", "\u09F0", "\u09F1", "\u0A05", "\u0A06", "\u0A07", "\u0A08", "\u0A09", "\u0A0A", "\u0A0F", "\u0A10", "\u0A13", "\u0A14", "\u0A15", "\u0A16", "\u0A17", "\u0A18", "\u0A19", "\u0A1A", "\u0A1B", "\u0A1C", "\u0A1D", "\u0A1E", "\u0A1F", "\u0A20", "\u0A21", "\u0A22", "\u0A23", "\u0A24", "\u0A25", "\u0A26", "\u0A27", "\u0A28", "\u0A2A", "\u0A2B", "\u0A2C", "\u0A2D", "\u0A2E", "\u0A2F", "\u0A30", "\u0A32", "\u0A33", "\u0A35", "\u0A36", "\u0A38", "\u0A39", "\u0A59", "\u0A5A", "\u0A5B", "\u0A5C", "\u0A5E", "\u0A72", "\u0A73", "\u0A74", "\u0A85", "\u0A86", "\u0A87", "\u0A88", "\u0A89", "\u0A8A", "\u0A8B", "\u0A8C", "\u0A8D", "\u0A8F", "\u0A90", "\u0A91", "\u0A93", "\u0A94", "\u0A95", "\u0A96", "\u0A97", "\u0A98", "\u0A99", "\u0A9A", "\u0A9B", "\u0A9C", "\u0A9D", "\u0A9E", "\u0A9F", "\u0AA0", "\u0AA1", "\u0AA2", "\u0AA3", "\u0AA4", "\u0AA5", "\u0AA6", "\u0AA7", "\u0AA8", "\u0AAA", "\u0AAB", "\u0AAC", "\u0AAD", "\u0AAE", "\u0AAF", "\u0AB0", "\u0AB2", "\u0AB3", "\u0AB5", "\u0AB6", "\u0AB7", "\u0AB8", "\u0AB9", "\u0ABD", "\u0AD0", "\u0AE0", "\u0AE1", "\u0B05", "\u0B06", "\u0B07", "\u0B08", "\u0B09", "\u0B0A", "\u0B0B", "\u0B0C", "\u0B0F", "\u0B10", "\u0B13", "\u0B14", "\u0B15", "\u0B16", "\u0B17", "\u0B18", "\u0B19", "\u0B1A", "\u0B1B", "\u0B1C", "\u0B1D", "\u0B1E", "\u0B1F", "\u0B20", "\u0B21", "\u0B22", "\u0B23", "\u0B24", "\u0B25", "\u0B26", "\u0B27", "\u0B28", "\u0B2A", "\u0B2B", "\u0B2C", "\u0B2D", "\u0B2E", "\u0B2F", "\u0B30", "\u0B32", "\u0B33", "\u0B35", "\u0B36", "\u0B37", "\u0B38", "\u0B39", "\u0B3D", "\u0B5C", "\u0B5D", "\u0B5F", "\u0B60", "\u0B61", "\u0B71", "\u0B83", "\u0B85", "\u0B86", "\u0B87", "\u0B88", "\u0B89", "\u0B8A", "\u0B8E", "\u0B8F", "\u0B90", "\u0B92", "\u0B93", "\u0B94", "\u0B95", "\u0B99", "\u0B9A", "\u0B9C", "\u0B9E", "\u0B9F", "\u0BA3", "\u0BA4", "\u0BA8", "\u0BA9", "\u0BAA", "\u0BAE", "\u0BAF", "\u0BB0", "\u0BB1", "\u0BB2", "\u0BB3", "\u0BB4", "\u0BB5", "\u0BB6", "\u0BB7", "\u0BB8", "\u0BB9", "\u0BD0", "\u0C05", "\u0C06", "\u0C07", "\u0C08", "\u0C09", "\u0C0A", "\u0C0B", "\u0C0C", "\u0C0E", "\u0C0F", "\u0C10", "\u0C12", "\u0C13", "\u0C14", "\u0C15", "\u0C16", "\u0C17", "\u0C18", "\u0C19", "\u0C1A", "\u0C1B", "\u0C1C", "\u0C1D", "\u0C1E", "\u0C1F", "\u0C20", "\u0C21", "\u0C22", "\u0C23", "\u0C24", "\u0C25", "\u0C26", "\u0C27", "\u0C28", "\u0C2A", "\u0C2B", "\u0C2C", "\u0C2D", "\u0C2E", "\u0C2F", "\u0C30", "\u0C31", "\u0C32", "\u0C33", "\u0C35", "\u0C36", "\u0C37", "\u0C38", "\u0C39", "\u0C3D", "\u0C58", "\u0C59", "\u0C60", "\u0C61", "\u0C85", "\u0C86", "\u0C87", "\u0C88", "\u0C89", "\u0C8A", "\u0C8B", "\u0C8C", "\u0C8E", "\u0C8F", "\u0C90", "\u0C92", "\u0C93", "\u0C94", "\u0C95", "\u0C96", "\u0C97", "\u0C98", "\u0C99", "\u0C9A", "\u0C9B", "\u0C9C", "\u0C9D", "\u0C9E", "\u0C9F", "\u0CA0", "\u0CA1", "\u0CA2", "\u0CA3", "\u0CA4", "\u0CA5", "\u0CA6", "\u0CA7", "\u0CA8", "\u0CAA", "\u0CAB", "\u0CAC", "\u0CAD", "\u0CAE", "\u0CAF", "\u0CB0", "\u0CB1", "\u0CB2", "\u0CB3", "\u0CB5", "\u0CB6", "\u0CB7", "\u0CB8", "\u0CB9", "\u0CBD", "\u0CDE", "\u0CE0", "\u0CE1", "\u0D05", "\u0D06", "\u0D07", "\u0D08", "\u0D09", "\u0D0A", "\u0D0B", "\u0D0C", "\u0D0E", "\u0D0F", "\u0D10", "\u0D12", "\u0D13", "\u0D14", "\u0D15", "\u0D16", "\u0D17", "\u0D18", "\u0D19", "\u0D1A", "\u0D1B", "\u0D1C", "\u0D1D", "\u0D1E", "\u0D1F", "\u0D20", "\u0D21", "\u0D22", "\u0D23", "\u0D24", "\u0D25", "\u0D26", "\u0D27", "\u0D28", "\u0D2A", "\u0D2B", "\u0D2C", "\u0D2D", "\u0D2E", "\u0D2F", "\u0D30", "\u0D31", "\u0D32", "\u0D33", "\u0D34", "\u0D35", "\u0D36", "\u0D37", "\u0D38", "\u0D39", "\u0D3D", "\u0D60", "\u0D61", "\u0D7A", "\u0D7B", "\u0D7C", "\u0D7D", "\u0D7E", "\u0D7F", "\u0D85", "\u0D86", "\u0D87", "\u0D88", "\u0D89", "\u0D8A", "\u0D8B", "\u0D8C", "\u0D8D", "\u0D8E", "\u0D8F", "\u0D90", "\u0D91", "\u0D92", "\u0D93", "\u0D94", "\u0D95", "\u0D96", "\u0D9A", "\u0D9B", "\u0D9C", "\u0D9D", "\u0D9E", "\u0D9F", "\u0DA0", "\u0DA1", "\u0DA2", "\u0DA3", "\u0DA4", "\u0DA5", "\u0DA6", "\u0DA7", "\u0DA8", "\u0DA9", "\u0DAA", "\u0DAB", "\u0DAC", "\u0DAD", "\u0DAE", "\u0DAF", "\u0DB0", "\u0DB1", "\u0DB3", "\u0DB4", "\u0DB5", "\u0DB6", "\u0DB7", "\u0DB8", "\u0DB9", "\u0DBA", "\u0DBB", "\u0DBD", "\u0DC0", "\u0DC1", "\u0DC2", "\u0DC3", "\u0DC4", "\u0DC5", "\u0DC6", "\u0E01", "\u0E02", "\u0E03", "\u0E04", "\u0E05", "\u0E06", "\u0E07", "\u0E08", "\u0E09", "\u0E0A", "\u0E0B", "\u0E0C", "\u0E0D", "\u0E0E", "\u0E0F", "\u0E10", "\u0E11", "\u0E12", "\u0E13", "\u0E14", "\u0E15", "\u0E16", "\u0E17", "\u0E18", "\u0E19", "\u0E1A", "\u0E1B", "\u0E1C", "\u0E1D", "\u0E1E", "\u0E1F", "\u0E20", "\u0E21", "\u0E22", "\u0E23", "\u0E24", "\u0E25", "\u0E26", "\u0E27", "\u0E28", "\u0E29", "\u0E2A", "\u0E2B", "\u0E2C", "\u0E2D", "\u0E2E", "\u0E2F", "\u0E30", "\u0E32", "\u0E33", "\u0E40", "\u0E41", "\u0E42", "\u0E43", "\u0E44", "\u0E45", "\u0E81", "\u0E82", "\u0E84", "\u0E87", "\u0E88", "\u0E8A", "\u0E8D", "\u0E94", "\u0E95", "\u0E96", "\u0E97", "\u0E99", "\u0E9A", "\u0E9B", "\u0E9C", "\u0E9D", "\u0E9E", "\u0E9F", "\u0EA1", "\u0EA2", "\u0EA3", "\u0EA5", "\u0EA7", "\u0EAA", "\u0EAB", "\u0EAD", "\u0EAE", "\u0EAF", "\u0EB0", "\u0EB2", "\u0EB3", "\u0EBD", "\u0EC0", "\u0EC1", "\u0EC2", "\u0EC3", "\u0EC4", "\u0EDC", "\u0EDD", "\u0F00", "\u0F40", "\u0F41", "\u0F42", "\u0F43", "\u0F44", "\u0F45", "\u0F46", "\u0F47", "\u0F49", "\u0F4A", "\u0F4B", "\u0F4C", "\u0F4D", "\u0F4E", "\u0F4F", "\u0F50", "\u0F51", "\u0F52", "\u0F53", "\u0F54", "\u0F55", "\u0F56", "\u0F57", "\u0F58", "\u0F59", "\u0F5A", "\u0F5B", "\u0F5C", "\u0F5D", "\u0F5E", "\u0F5F", "\u0F60", "\u0F61", "\u0F62", "\u0F63", "\u0F64", "\u0F65", "\u0F66", "\u0F67", "\u0F68", "\u0F69", "\u0F6A", "\u0F6B", "\u0F6C", "\u0F88", "\u0F89", "\u0F8A", "\u0F8B", "\u1000", "\u1001", "\u1002", "\u1003", "\u1004", "\u1005", "\u1006", "\u1007", "\u1008", "\u1009", "\u100A", "\u100B", "\u100C", "\u100D", "\u100E", "\u100F", "\u1010", "\u1011", "\u1012", "\u1013", "\u1014", "\u1015", "\u1016", "\u1017", "\u1018", "\u1019", "\u101A", "\u101B", "\u101C", "\u101D", "\u101E", "\u101F", "\u1020", "\u1021", "\u1022", "\u1023", "\u1024", "\u1025", "\u1026", "\u1027", "\u1028", "\u1029", "\u102A", "\u103F", "\u1050", "\u1051", "\u1052", "\u1053", "\u1054", "\u1055", "\u105A", "\u105B", "\u105C", "\u105D", "\u1061", "\u1065", "\u1066", "\u106E", "\u106F", "\u1070", "\u1075", "\u1076", "\u1077", "\u1078", "\u1079", "\u107A", "\u107B", "\u107C", "\u107D", "\u107E", "\u107F", "\u1080", "\u1081", "\u108E", "\u10D0", "\u10D1", "\u10D2", "\u10D3", "\u10D4", "\u10D5", "\u10D6", "\u10D7", "\u10D8", "\u10D9", "\u10DA", "\u10DB", "\u10DC", "\u10DD", "\u10DE", "\u10DF", "\u10E0", "\u10E1", "\u10E2", "\u10E3", "\u10E4", "\u10E5", "\u10E6", "\u10E7", "\u10E8", "\u10E9", "\u10EA", "\u10EB", "\u10EC", "\u10ED", "\u10EE", "\u10EF", "\u10F0", "\u10F1", "\u10F2", "\u10F3", "\u10F4", "\u10F5", "\u10F6", "\u10F7", "\u10F8", "\u10F9", "\u10FA", "\u1100", "\u1101", "\u1102", "\u1103", "\u1104", "\u1105", "\u1106", "\u1107", "\u1108", "\u1109", "\u110A", "\u110B", "\u110C", "\u110D", "\u110E", "\u110F", "\u1110", "\u1111", "\u1112", "\u1113", "\u1114", "\u1115", "\u1116", "\u1117", "\u1118", "\u1119", "\u111A", "\u111B", "\u111C", "\u111D", "\u111E", "\u111F", "\u1120", "\u1121", "\u1122", "\u1123", "\u1124", "\u1125", "\u1126", "\u1127", "\u1128", "\u1129", "\u112A", "\u112B", "\u112C", "\u112D", "\u112E", "\u112F", "\u1130", "\u1131", "\u1132", "\u1133", "\u1134", "\u1135", "\u1136", "\u1137", "\u1138", "\u1139", "\u113A", "\u113B", "\u113C", "\u113D", "\u113E", "\u113F", "\u1140", "\u1141", "\u1142", "\u1143", "\u1144", "\u1145", "\u1146", "\u1147", "\u1148", "\u1149", "\u114A", "\u114B", "\u114C", "\u114D", "\u114E", "\u114F", "\u1150", "\u1151", "\u1152", "\u1153", "\u1154", "\u1155", "\u1156", "\u1157", "\u1158", "\u1159", "\u115F", "\u1160", "\u1161", "\u1162", "\u1163", "\u1164", "\u1165", "\u1166", "\u1167", "\u1168", "\u1169", "\u116A", "\u116B", "\u116C", "\u116D", "\u116E", "\u116F", "\u1170", "\u1171", "\u1172", "\u1173", "\u1174", "\u1175", "\u1176", "\u1177", "\u1178", "\u1179", "\u117A", "\u117B", "\u117C", "\u117D", "\u117E", "\u117F", "\u1180", "\u1181", "\u1182", "\u1183", "\u1184", "\u1185", "\u1186", "\u1187", "\u1188", "\u1189", "\u118A", "\u118B", "\u118C", "\u118D", "\u118E", "\u118F", "\u1190", "\u1191", "\u1192", "\u1193", "\u1194", "\u1195", "\u1196", "\u1197", "\u1198", "\u1199", "\u119A", "\u119B", "\u119C", "\u119D", "\u119E", "\u119F", "\u11A0", "\u11A1", "\u11A2", "\u11A8", "\u11A9", "\u11AA", "\u11AB", "\u11AC", "\u11AD", "\u11AE", "\u11AF", "\u11B0", "\u11B1", "\u11B2", "\u11B3", "\u11B4", "\u11B5", "\u11B6", "\u11B7", "\u11B8", "\u11B9", "\u11BA", "\u11BB", "\u11BC", "\u11BD", "\u11BE", "\u11BF", "\u11C0", "\u11C1", "\u11C2", "\u11C3", "\u11C4", "\u11C5", "\u11C6", "\u11C7", "\u11C8", "\u11C9", "\u11CA", "\u11CB", "\u11CC", "\u11CD", "\u11CE", "\u11CF", "\u11D0", "\u11D1", "\u11D2", "\u11D3", "\u11D4", "\u11D5", "\u11D6", "\u11D7", "\u11D8", "\u11D9", "\u11DA", "\u11DB", "\u11DC", "\u11DD", "\u11DE", "\u11DF", "\u11E0", "\u11E1", "\u11E2", "\u11E3", "\u11E4", "\u11E5", "\u11E6", "\u11E7", "\u11E8", "\u11E9", "\u11EA", "\u11EB", "\u11EC", "\u11ED", "\u11EE", "\u11EF", "\u11F0", "\u11F1", "\u11F2", "\u11F3", "\u11F4", "\u11F5", "\u11F6", "\u11F7", "\u11F8", "\u11F9", "\u1200", "\u1201", "\u1202", "\u1203", "\u1204", "\u1205", "\u1206", "\u1207", "\u1208", "\u1209", "\u120A", "\u120B", "\u120C", "\u120D", "\u120E", "\u120F", "\u1210", "\u1211", "\u1212", "\u1213", "\u1214", "\u1215", "\u1216", "\u1217", "\u1218", "\u1219", "\u121A", "\u121B", "\u121C", "\u121D", "\u121E", "\u121F", "\u1220", "\u1221", "\u1222", "\u1223", "\u1224", "\u1225", "\u1226", "\u1227", "\u1228", "\u1229", "\u122A", "\u122B", "\u122C", "\u122D", "\u122E", "\u122F", "\u1230", "\u1231", "\u1232", "\u1233", "\u1234", "\u1235", "\u1236", "\u1237", "\u1238", "\u1239", "\u123A", "\u123B", "\u123C", "\u123D", "\u123E", "\u123F", "\u1240", "\u1241", "\u1242", "\u1243", "\u1244", "\u1245", "\u1246", "\u1247", "\u1248", "\u124A", "\u124B", "\u124C", "\u124D", "\u1250", "\u1251", "\u1252", "\u1253", "\u1254", "\u1255", "\u1256", "\u1258", "\u125A", "\u125B", "\u125C", "\u125D", "\u1260", "\u1261", "\u1262", "\u1263", "\u1264", "\u1265", "\u1266", "\u1267", "\u1268", "\u1269", "\u126A", "\u126B", "\u126C", "\u126D", "\u126E", "\u126F", "\u1270", "\u1271", "\u1272", "\u1273", "\u1274", "\u1275", "\u1276", "\u1277", "\u1278", "\u1279", "\u127A", "\u127B", "\u127C", "\u127D", "\u127E", "\u127F", "\u1280", "\u1281", "\u1282", "\u1283", "\u1284", "\u1285", "\u1286", "\u1287", "\u1288", "\u128A", "\u128B", "\u128C", "\u128D", "\u1290", "\u1291", "\u1292", "\u1293", "\u1294", "\u1295", "\u1296", "\u1297", "\u1298", "\u1299", "\u129A", "\u129B", "\u129C", "\u129D", "\u129E", "\u129F", "\u12A0", "\u12A1", "\u12A2", "\u12A3", "\u12A4", "\u12A5", "\u12A6", "\u12A7", "\u12A8", "\u12A9", "\u12AA", "\u12AB", "\u12AC", "\u12AD", "\u12AE", "\u12AF", "\u12B0", "\u12B2", "\u12B3", "\u12B4", "\u12B5", "\u12B8", "\u12B9", "\u12BA", "\u12BB", "\u12BC", "\u12BD", "\u12BE", "\u12C0", "\u12C2", "\u12C3", "\u12C4", "\u12C5", "\u12C8", "\u12C9", "\u12CA", "\u12CB", "\u12CC", "\u12CD", "\u12CE", "\u12CF", "\u12D0", "\u12D1", "\u12D2", "\u12D3", "\u12D4", "\u12D5", "\u12D6", "\u12D8", "\u12D9", "\u12DA", "\u12DB", "\u12DC", "\u12DD", "\u12DE", "\u12DF", "\u12E0", "\u12E1", "\u12E2", "\u12E3", "\u12E4", "\u12E5", "\u12E6", "\u12E7", "\u12E8", "\u12E9", "\u12EA", "\u12EB", "\u12EC", "\u12ED", "\u12EE", "\u12EF", "\u12F0", "\u12F1", "\u12F2", "\u12F3", "\u12F4", "\u12F5", "\u12F6", "\u12F7", "\u12F8", "\u12F9", "\u12FA", "\u12FB", "\u12FC", "\u12FD", "\u12FE", "\u12FF", "\u1300", "\u1301", "\u1302", "\u1303", "\u1304", "\u1305", "\u1306", "\u1307", "\u1308", "\u1309", "\u130A", "\u130B", "\u130C", "\u130D", "\u130E", "\u130F", "\u1310", "\u1312", "\u1313", "\u1314", "\u1315", "\u1318", "\u1319", "\u131A", "\u131B", "\u131C", "\u131D", "\u131E", "\u131F", "\u1320", "\u1321", "\u1322", "\u1323", "\u1324", "\u1325", "\u1326", "\u1327", "\u1328", "\u1329", "\u132A", "\u132B", "\u132C", "\u132D", "\u132E", "\u132F", "\u1330", "\u1331", "\u1332", "\u1333", "\u1334", "\u1335", "\u1336", "\u1337", "\u1338", "\u1339", "\u133A", "\u133B", "\u133C", "\u133D", "\u133E", "\u133F", "\u1340", "\u1341", "\u1342", "\u1343", "\u1344", "\u1345", "\u1346", "\u1347", "\u1348", "\u1349", "\u134A", "\u134B", "\u134C", "\u134D", "\u134E", "\u134F", "\u1350", "\u1351", "\u1352", "\u1353", "\u1354", "\u1355", "\u1356", "\u1357", "\u1358", "\u1359", "\u135A", "\u1380", "\u1381", "\u1382", "\u1383", "\u1384", "\u1385", "\u1386", "\u1387", "\u1388", "\u1389", "\u138A", "\u138B", "\u138C", "\u138D", "\u138E", "\u138F", "\u13A0", "\u13A1", "\u13A2", "\u13A3", "\u13A4", "\u13A5", "\u13A6", "\u13A7", "\u13A8", "\u13A9", "\u13AA", "\u13AB", "\u13AC", "\u13AD", "\u13AE", "\u13AF", "\u13B0", "\u13B1", "\u13B2", "\u13B3", "\u13B4", "\u13B5", "\u13B6", "\u13B7", "\u13B8", "\u13B9", "\u13BA", "\u13BB", "\u13BC", "\u13BD", "\u13BE", "\u13BF", "\u13C0", "\u13C1", "\u13C2", "\u13C3", "\u13C4", "\u13C5", "\u13C6", "\u13C7", "\u13C8", "\u13C9", "\u13CA", "\u13CB", "\u13CC", "\u13CD", "\u13CE", "\u13CF", "\u13D0", "\u13D1", "\u13D2", "\u13D3", "\u13D4", "\u13D5", "\u13D6", "\u13D7", "\u13D8", "\u13D9", "\u13DA", "\u13DB", "\u13DC", "\u13DD", "\u13DE", "\u13DF", "\u13E0", "\u13E1", "\u13E2", "\u13E3", "\u13E4", "\u13E5", "\u13E6", "\u13E7", "\u13E8", "\u13E9", "\u13EA", "\u13EB", "\u13EC", "\u13ED", "\u13EE", "\u13EF", "\u13F0", "\u13F1", "\u13F2", "\u13F3", "\u13F4", "\u1401", "\u1402", "\u1403", "\u1404", "\u1405", "\u1406", "\u1407", "\u1408", "\u1409", "\u140A", "\u140B", "\u140C", "\u140D", "\u140E", "\u140F", "\u1410", "\u1411", "\u1412", "\u1413", "\u1414", "\u1415", "\u1416", "\u1417", "\u1418", "\u1419", "\u141A", "\u141B", "\u141C", "\u141D", "\u141E", "\u141F", "\u1420", "\u1421", "\u1422", "\u1423", "\u1424", "\u1425", "\u1426", "\u1427", "\u1428", "\u1429", "\u142A", "\u142B", "\u142C", "\u142D", "\u142E", "\u142F", "\u1430", "\u1431", "\u1432", "\u1433", "\u1434", "\u1435", "\u1436", "\u1437", "\u1438", "\u1439", "\u143A", "\u143B", "\u143C", "\u143D", "\u143E", "\u143F", "\u1440", "\u1441", "\u1442", "\u1443", "\u1444", "\u1445", "\u1446", "\u1447", "\u1448", "\u1449", "\u144A", "\u144B", "\u144C", "\u144D", "\u144E", "\u144F", "\u1450", "\u1451", "\u1452", "\u1453", "\u1454", "\u1455", "\u1456", "\u1457", "\u1458", "\u1459", "\u145A", "\u145B", "\u145C", "\u145D", "\u145E", "\u145F", "\u1460", "\u1461", "\u1462", "\u1463", "\u1464", "\u1465", "\u1466", "\u1467", "\u1468", "\u1469", "\u146A", "\u146B", "\u146C", "\u146D", "\u146E", "\u146F", "\u1470", "\u1471", "\u1472", "\u1473", "\u1474", "\u1475", "\u1476", "\u1477", "\u1478", "\u1479", "\u147A", "\u147B", "\u147C", "\u147D", "\u147E", "\u147F", "\u1480", "\u1481", "\u1482", "\u1483", "\u1484", "\u1485", "\u1486", "\u1487", "\u1488", "\u1489", "\u148A", "\u148B", "\u148C", "\u148D", "\u148E", "\u148F", "\u1490", "\u1491", "\u1492", "\u1493", "\u1494", "\u1495", "\u1496", "\u1497", "\u1498", "\u1499", "\u149A", "\u149B", "\u149C", "\u149D", "\u149E", "\u149F", "\u14A0", "\u14A1", "\u14A2", "\u14A3", "\u14A4", "\u14A5", "\u14A6", "\u14A7", "\u14A8", "\u14A9", "\u14AA", "\u14AB", "\u14AC", "\u14AD", "\u14AE", "\u14AF", "\u14B0", "\u14B1", "\u14B2", "\u14B3", "\u14B4", "\u14B5", "\u14B6", "\u14B7", "\u14B8", "\u14B9", "\u14BA", "\u14BB", "\u14BC", "\u14BD", "\u14BE", "\u14BF", "\u14C0", "\u14C1", "\u14C2", "\u14C3", "\u14C4", "\u14C5", "\u14C6", "\u14C7", "\u14C8", "\u14C9", "\u14CA", "\u14CB", "\u14CC", "\u14CD", "\u14CE", "\u14CF", "\u14D0", "\u14D1", "\u14D2", "\u14D3", "\u14D4", "\u14D5", "\u14D6", "\u14D7", "\u14D8", "\u14D9", "\u14DA", "\u14DB", "\u14DC", "\u14DD", "\u14DE", "\u14DF", "\u14E0", "\u14E1", "\u14E2", "\u14E3", "\u14E4", "\u14E5", "\u14E6", "\u14E7", "\u14E8", "\u14E9", "\u14EA", "\u14EB", "\u14EC", "\u14ED", "\u14EE", "\u14EF", "\u14F0", "\u14F1", "\u14F2", "\u14F3", "\u14F4", "\u14F5", "\u14F6", "\u14F7", "\u14F8", "\u14F9", "\u14FA", "\u14FB", "\u14FC", "\u14FD", "\u14FE", "\u14FF", "\u1500", "\u1501", "\u1502", "\u1503", "\u1504", "\u1505", "\u1506", "\u1507", "\u1508", "\u1509", "\u150A", "\u150B", "\u150C", "\u150D", "\u150E", "\u150F", "\u1510", "\u1511", "\u1512", "\u1513", "\u1514", "\u1515", "\u1516", "\u1517", "\u1518", "\u1519", "\u151A", "\u151B", "\u151C", "\u151D", "\u151E", "\u151F", "\u1520", "\u1521", "\u1522", "\u1523", "\u1524", "\u1525", "\u1526", "\u1527", "\u1528", "\u1529", "\u152A", "\u152B", "\u152C", "\u152D", "\u152E", "\u152F", "\u1530", "\u1531", "\u1532", "\u1533", "\u1534", "\u1535", "\u1536", "\u1537", "\u1538", "\u1539", "\u153A", "\u153B", "\u153C", "\u153D", "\u153E", "\u153F", "\u1540", "\u1541", "\u1542", "\u1543", "\u1544", "\u1545", "\u1546", "\u1547", "\u1548", "\u1549", "\u154A", "\u154B", "\u154C", "\u154D", "\u154E", "\u154F", "\u1550", "\u1551", "\u1552", "\u1553", "\u1554", "\u1555", "\u1556", "\u1557", "\u1558", "\u1559", "\u155A", "\u155B", "\u155C", "\u155D", "\u155E", "\u155F", "\u1560", "\u1561", "\u1562", "\u1563", "\u1564", "\u1565", "\u1566", "\u1567", "\u1568", "\u1569", "\u156A", "\u156B", "\u156C", "\u156D", "\u156E", "\u156F", "\u1570", "\u1571", "\u1572", "\u1573", "\u1574", "\u1575", "\u1576", "\u1577", "\u1578", "\u1579", "\u157A", "\u157B", "\u157C", "\u157D", "\u157E", "\u157F", "\u1580", "\u1581", "\u1582", "\u1583", "\u1584", "\u1585", "\u1586", "\u1587", "\u1588", "\u1589", "\u158A", "\u158B", "\u158C", "\u158D", "\u158E", "\u158F", "\u1590", "\u1591", "\u1592", "\u1593", "\u1594", "\u1595", "\u1596", "\u1597", "\u1598", "\u1599", "\u159A", "\u159B", "\u159C", "\u159D", "\u159E", "\u159F", "\u15A0", "\u15A1", "\u15A2", "\u15A3", "\u15A4", "\u15A5", "\u15A6", "\u15A7", "\u15A8", "\u15A9", "\u15AA", "\u15AB", "\u15AC", "\u15AD", "\u15AE", "\u15AF", "\u15B0", "\u15B1", "\u15B2", "\u15B3", "\u15B4", "\u15B5", "\u15B6", "\u15B7", "\u15B8", "\u15B9", "\u15BA", "\u15BB", "\u15BC", "\u15BD", "\u15BE", "\u15BF", "\u15C0", "\u15C1", "\u15C2", "\u15C3", "\u15C4", "\u15C5", "\u15C6", "\u15C7", "\u15C8", "\u15C9", "\u15CA", "\u15CB", "\u15CC", "\u15CD", "\u15CE", "\u15CF", "\u15D0", "\u15D1", "\u15D2", "\u15D3", "\u15D4", "\u15D5", "\u15D6", "\u15D7", "\u15D8", "\u15D9", "\u15DA", "\u15DB", "\u15DC", "\u15DD", "\u15DE", "\u15DF", "\u15E0", "\u15E1", "\u15E2", "\u15E3", "\u15E4", "\u15E5", "\u15E6", "\u15E7", "\u15E8", "\u15E9", "\u15EA", "\u15EB", "\u15EC", "\u15ED", "\u15EE", "\u15EF", "\u15F0", "\u15F1", "\u15F2", "\u15F3", "\u15F4", "\u15F5", "\u15F6", "\u15F7", "\u15F8", "\u15F9", "\u15FA", "\u15FB", "\u15FC", "\u15FD", "\u15FE", "\u15FF", "\u1600", "\u1601", "\u1602", "\u1603", "\u1604", "\u1605", "\u1606", "\u1607", "\u1608", "\u1609", "\u160A", "\u160B", "\u160C", "\u160D", "\u160E", "\u160F", "\u1610", "\u1611", "\u1612", "\u1613", "\u1614", "\u1615", "\u1616", "\u1617", "\u1618", "\u1619", "\u161A", "\u161B", "\u161C", "\u161D", "\u161E", "\u161F", "\u1620", "\u1621", "\u1622", "\u1623", "\u1624", "\u1625", "\u1626", "\u1627", "\u1628", "\u1629", "\u162A", "\u162B", "\u162C", "\u162D", "\u162E", "\u162F", "\u1630", "\u1631", "\u1632", "\u1633", "\u1634", "\u1635", "\u1636", "\u1637", "\u1638", "\u1639", "\u163A", "\u163B", "\u163C", "\u163D", "\u163E", "\u163F", "\u1640", "\u1641", "\u1642", "\u1643", "\u1644", "\u1645", "\u1646", "\u1647", "\u1648", "\u1649", "\u164A", "\u164B", "\u164C", "\u164D", "\u164E", "\u164F", "\u1650", "\u1651", "\u1652", "\u1653", "\u1654", "\u1655", "\u1656", "\u1657", "\u1658", "\u1659", "\u165A", "\u165B", "\u165C", "\u165D", "\u165E", "\u165F", "\u1660", "\u1661", "\u1662", "\u1663", "\u1664", "\u1665", "\u1666", "\u1667", "\u1668", "\u1669", "\u166A", "\u166B", "\u166C", "\u166F", "\u1670", "\u1671", "\u1672", "\u1673", "\u1674", "\u1675", "\u1676", "\u1681", "\u1682", "\u1683", "\u1684", "\u1685", "\u1686", "\u1687", "\u1688", "\u1689", "\u168A", "\u168B", "\u168C", "\u168D", "\u168E", "\u168F", "\u1690", "\u1691", "\u1692", "\u1693", "\u1694", "\u1695", "\u1696", "\u1697", "\u1698", "\u1699", "\u169A", "\u16A0", "\u16A1", "\u16A2", "\u16A3", "\u16A4", "\u16A5", "\u16A6", "\u16A7", "\u16A8", "\u16A9", "\u16AA", "\u16AB", "\u16AC", "\u16AD", "\u16AE", "\u16AF", "\u16B0", "\u16B1", "\u16B2", "\u16B3", "\u16B4", "\u16B5", "\u16B6", "\u16B7", "\u16B8", "\u16B9", "\u16BA", "\u16BB", "\u16BC", "\u16BD", "\u16BE", "\u16BF", "\u16C0", "\u16C1", "\u16C2", "\u16C3", "\u16C4", "\u16C5", "\u16C6", "\u16C7", "\u16C8", "\u16C9", "\u16CA", "\u16CB", "\u16CC", "\u16CD", "\u16CE", "\u16CF", "\u16D0", "\u16D1", "\u16D2", "\u16D3", "\u16D4", "\u16D5", "\u16D6", "\u16D7", "\u16D8", "\u16D9", "\u16DA", "\u16DB", "\u16DC", "\u16DD", "\u16DE", "\u16DF", "\u16E0", "\u16E1", "\u16E2", "\u16E3", "\u16E4", "\u16E5", "\u16E6", "\u16E7", "\u16E8", "\u16E9", "\u16EA", "\u1700", "\u1701", "\u1702", "\u1703", "\u1704", "\u1705", "\u1706", "\u1707", "\u1708", "\u1709", "\u170A", "\u170B", "\u170C", "\u170E", "\u170F", "\u1710", "\u1711", "\u1720", "\u1721", "\u1722", "\u1723", "\u1724", "\u1725", "\u1726", "\u1727", "\u1728", "\u1729", "\u172A", "\u172B", "\u172C", "\u172D", "\u172E", "\u172F", "\u1730", "\u1731", "\u1740", "\u1741", "\u1742", "\u1743", "\u1744", "\u1745", "\u1746", "\u1747", "\u1748", "\u1749", "\u174A", "\u174B", "\u174C", "\u174D", "\u174E", "\u174F", "\u1750", "\u1751", "\u1760", "\u1761", "\u1762", "\u1763", "\u1764", "\u1765", "\u1766", "\u1767", "\u1768", "\u1769", "\u176A", "\u176B", "\u176C", "\u176E", "\u176F", "\u1770", "\u1780", "\u1781", "\u1782", "\u1783", "\u1784", "\u1785", "\u1786", "\u1787", "\u1788", "\u1789", "\u178A", "\u178B", "\u178C", "\u178D", "\u178E", "\u178F", "\u1790", "\u1791", "\u1792", "\u1793", "\u1794", "\u1795", "\u1796", "\u1797", "\u1798", "\u1799", "\u179A", "\u179B", "\u179C", "\u179D", "\u179E", "\u179F", "\u17A0", "\u17A1", "\u17A2", "\u17A3", "\u17A4", "\u17A5", "\u17A6", "\u17A7", "\u17A8", "\u17A9", "\u17AA", "\u17AB", "\u17AC", "\u17AD", "\u17AE", "\u17AF", "\u17B0", "\u17B1", "\u17B2", "\u17B3", "\u17DC", "\u1820", "\u1821", "\u1822", "\u1823", "\u1824", "\u1825", "\u1826", "\u1827", "\u1828", "\u1829", "\u182A", "\u182B", "\u182C", "\u182D", "\u182E", "\u182F", "\u1830", "\u1831", "\u1832", "\u1833", "\u1834", "\u1835", "\u1836", "\u1837", "\u1838", "\u1839", "\u183A", "\u183B", "\u183C", "\u183D", "\u183E", "\u183F", "\u1840", "\u1841", "\u1842", "\u1844", "\u1845", "\u1846", "\u1847", "\u1848", "\u1849", "\u184A", "\u184B", "\u184C", "\u184D", "\u184E", "\u184F", "\u1850", "\u1851", "\u1852", "\u1853", "\u1854", "\u1855", "\u1856", "\u1857", "\u1858", "\u1859", "\u185A", "\u185B", "\u185C", "\u185D", "\u185E", "\u185F", "\u1860", "\u1861", "\u1862", "\u1863", "\u1864", "\u1865", "\u1866", "\u1867", "\u1868", "\u1869", "\u186A", "\u186B", "\u186C", "\u186D", "\u186E", "\u186F", "\u1870", "\u1871", "\u1872", "\u1873", "\u1874", "\u1875", "\u1876", "\u1877", "\u1880", "\u1881", "\u1882", "\u1883", "\u1884", "\u1885", "\u1886", "\u1887", "\u1888", "\u1889", "\u188A", "\u188B", "\u188C", "\u188D", "\u188E", "\u188F", "\u1890", "\u1891", "\u1892", "\u1893", "\u1894", "\u1895", "\u1896", "\u1897", "\u1898", "\u1899", "\u189A", "\u189B", "\u189C", "\u189D", "\u189E", "\u189F", "\u18A0", "\u18A1", "\u18A2", "\u18A3", "\u18A4", "\u18A5", "\u18A6", "\u18A7", "\u18A8", "\u18AA", "\u1900", "\u1901", "\u1902", "\u1903", "\u1904", "\u1905", "\u1906", "\u1907", "\u1908", "\u1909", "\u190A", "\u190B", "\u190C", "\u190D", "\u190E", "\u190F", "\u1910", "\u1911", "\u1912", "\u1913", "\u1914", "\u1915", "\u1916", "\u1917", "\u1918", "\u1919", "\u191A", "\u191B", "\u191C", "\u1950", "\u1951", "\u1952", "\u1953", "\u1954", "\u1955", "\u1956", "\u1957", "\u1958", "\u1959", "\u195A", "\u195B", "\u195C", "\u195D", "\u195E", "\u195F", "\u1960", "\u1961", "\u1962", "\u1963", "\u1964", "\u1965", "\u1966", "\u1967", "\u1968", "\u1969", "\u196A", "\u196B", "\u196C", "\u196D", "\u1970", "\u1971", "\u1972", "\u1973", "\u1974", "\u1980", "\u1981", "\u1982", "\u1983", "\u1984", "\u1985", "\u1986", "\u1987", "\u1988", "\u1989", "\u198A", "\u198B", "\u198C", "\u198D", "\u198E", "\u198F", "\u1990", "\u1991", "\u1992", "\u1993", "\u1994", "\u1995", "\u1996", "\u1997", "\u1998", "\u1999", "\u199A", "\u199B", "\u199C", "\u199D", "\u199E", "\u199F", "\u19A0", "\u19A1", "\u19A2", "\u19A3", "\u19A4", "\u19A5", "\u19A6", "\u19A7", "\u19A8", "\u19A9", "\u19C1", "\u19C2", "\u19C3", "\u19C4", "\u19C5", "\u19C6", "\u19C7", "\u1A00", "\u1A01", "\u1A02", "\u1A03", "\u1A04", "\u1A05", "\u1A06", "\u1A07", "\u1A08", "\u1A09", "\u1A0A", "\u1A0B", "\u1A0C", "\u1A0D", "\u1A0E", "\u1A0F", "\u1A10", "\u1A11", "\u1A12", "\u1A13", "\u1A14", "\u1A15", "\u1A16", "\u1B05", "\u1B06", "\u1B07", "\u1B08", "\u1B09", "\u1B0A", "\u1B0B", "\u1B0C", "\u1B0D", "\u1B0E", "\u1B0F", "\u1B10", "\u1B11", "\u1B12", "\u1B13", "\u1B14", "\u1B15", "\u1B16", "\u1B17", "\u1B18", "\u1B19", "\u1B1A", "\u1B1B", "\u1B1C", "\u1B1D", "\u1B1E", "\u1B1F", "\u1B20", "\u1B21", "\u1B22", "\u1B23", "\u1B24", "\u1B25", "\u1B26", "\u1B27", "\u1B28", "\u1B29", "\u1B2A", "\u1B2B", "\u1B2C", "\u1B2D", "\u1B2E", "\u1B2F", "\u1B30", "\u1B31", "\u1B32", "\u1B33", "\u1B45", "\u1B46", "\u1B47", "\u1B48", "\u1B49", "\u1B4A", "\u1B4B", "\u1B83", "\u1B84", "\u1B85", "\u1B86", "\u1B87", "\u1B88", "\u1B89", "\u1B8A", "\u1B8B", "\u1B8C", "\u1B8D", "\u1B8E", "\u1B8F", "\u1B90", "\u1B91", "\u1B92", "\u1B93", "\u1B94", "\u1B95", "\u1B96", "\u1B97", "\u1B98", "\u1B99", "\u1B9A", "\u1B9B", "\u1B9C", "\u1B9D", "\u1B9E", "\u1B9F", "\u1BA0", "\u1BAE", "\u1BAF", "\u1C00", "\u1C01", "\u1C02", "\u1C03", "\u1C04", "\u1C05", "\u1C06", "\u1C07", "\u1C08", "\u1C09", "\u1C0A", "\u1C0B", "\u1C0C", "\u1C0D", "\u1C0E", "\u1C0F", "\u1C10", "\u1C11", "\u1C12", "\u1C13", "\u1C14", "\u1C15", "\u1C16", "\u1C17", "\u1C18", "\u1C19", "\u1C1A", "\u1C1B", "\u1C1C", "\u1C1D", "\u1C1E", "\u1C1F", "\u1C20", "\u1C21", "\u1C22", "\u1C23", "\u1C4D", "\u1C4E", "\u1C4F", "\u1C5A", "\u1C5B", "\u1C5C", "\u1C5D", "\u1C5E", "\u1C5F", "\u1C60", "\u1C61", "\u1C62", "\u1C63", "\u1C64", "\u1C65", "\u1C66", "\u1C67", "\u1C68", "\u1C69", "\u1C6A", "\u1C6B", "\u1C6C", "\u1C6D", "\u1C6E", "\u1C6F", "\u1C70", "\u1C71", "\u1C72", "\u1C73", "\u1C74", "\u1C75", "\u1C76", "\u1C77", "\u2135", "\u2136", "\u2137", "\u2138", "\u2D30", "\u2D31", "\u2D32", "\u2D33", "\u2D34", "\u2D35", "\u2D36", "\u2D37", "\u2D38", "\u2D39", "\u2D3A", "\u2D3B", "\u2D3C", "\u2D3D", "\u2D3E", "\u2D3F", "\u2D40", "\u2D41", "\u2D42", "\u2D43", "\u2D44", "\u2D45", "\u2D46", "\u2D47", "\u2D48", "\u2D49", "\u2D4A", "\u2D4B", "\u2D4C", "\u2D4D", "\u2D4E", "\u2D4F", "\u2D50", "\u2D51", "\u2D52", "\u2D53", "\u2D54", "\u2D55", "\u2D56", "\u2D57", "\u2D58", "\u2D59", "\u2D5A", "\u2D5B", "\u2D5C", "\u2D5D", "\u2D5E", "\u2D5F", "\u2D60", "\u2D61", "\u2D62", "\u2D63", "\u2D64", "\u2D65", "\u2D80", "\u2D81", "\u2D82", "\u2D83", "\u2D84", "\u2D85", "\u2D86", "\u2D87", "\u2D88", "\u2D89", "\u2D8A", "\u2D8B", "\u2D8C", "\u2D8D", "\u2D8E", "\u2D8F", "\u2D90", "\u2D91", "\u2D92", "\u2D93", "\u2D94", "\u2D95", "\u2D96", "\u2DA0", "\u2DA1", "\u2DA2", "\u2DA3", "\u2DA4", "\u2DA5", "\u2DA6", "\u2DA8", "\u2DA9", "\u2DAA", "\u2DAB", "\u2DAC", "\u2DAD", "\u2DAE", "\u2DB0", "\u2DB1", "\u2DB2", "\u2DB3", "\u2DB4", "\u2DB5", "\u2DB6", "\u2DB8", "\u2DB9", "\u2DBA", "\u2DBB", "\u2DBC", "\u2DBD", "\u2DBE", "\u2DC0", "\u2DC1", "\u2DC2", "\u2DC3", "\u2DC4", "\u2DC5", "\u2DC6", "\u2DC8", "\u2DC9", "\u2DCA", "\u2DCB", "\u2DCC", "\u2DCD", "\u2DCE", "\u2DD0", "\u2DD1", "\u2DD2", "\u2DD3", "\u2DD4", "\u2DD5", "\u2DD6", "\u2DD8", "\u2DD9", "\u2DDA", "\u2DDB", "\u2DDC", "\u2DDD", "\u2DDE", "\u3006", "\u303C", "\u3041", "\u3042", "\u3043", "\u3044", "\u3045", "\u3046", "\u3047", "\u3048", "\u3049", "\u304A", "\u304B", "\u304C", "\u304D", "\u304E", "\u304F", "\u3050", "\u3051", "\u3052", "\u3053", "\u3054", "\u3055", "\u3056", "\u3057", "\u3058", "\u3059", "\u305A", "\u305B", "\u305C", "\u305D", "\u305E", "\u305F", "\u3060", "\u3061", "\u3062", "\u3063", "\u3064", "\u3065", "\u3066", "\u3067", "\u3068", "\u3069", "\u306A", "\u306B", "\u306C", "\u306D", "\u306E", "\u306F", "\u3070", "\u3071", "\u3072", "\u3073", "\u3074", "\u3075", "\u3076", "\u3077", "\u3078", "\u3079", "\u307A", "\u307B", "\u307C", "\u307D", "\u307E", "\u307F", "\u3080", "\u3081", "\u3082", "\u3083", "\u3084", "\u3085", "\u3086", "\u3087", "\u3088", "\u3089", "\u308A", "\u308B", "\u308C", "\u308D", "\u308E", "\u308F", "\u3090", "\u3091", "\u3092", "\u3093", "\u3094", "\u3095", "\u3096", "\u309F", "\u30A1", "\u30A2", "\u30A3", "\u30A4", "\u30A5", "\u30A6", "\u30A7", "\u30A8", "\u30A9", "\u30AA", "\u30AB", "\u30AC", "\u30AD", "\u30AE", "\u30AF", "\u30B0", "\u30B1", "\u30B2", "\u30B3", "\u30B4", "\u30B5", "\u30B6", "\u30B7", "\u30B8", "\u30B9", "\u30BA", "\u30BB", "\u30BC", "\u30BD", "\u30BE", "\u30BF", "\u30C0", "\u30C1", "\u30C2", "\u30C3", "\u30C4", "\u30C5", "\u30C6", "\u30C7", "\u30C8", "\u30C9", "\u30CA", "\u30CB", "\u30CC", "\u30CD", "\u30CE", "\u30CF", "\u30D0", "\u30D1", "\u30D2", "\u30D3", "\u30D4", "\u30D5", "\u30D6", "\u30D7", "\u30D8", "\u30D9", "\u30DA", "\u30DB", "\u30DC", "\u30DD", "\u30DE", "\u30DF", "\u30E0", "\u30E1", "\u30E2", "\u30E3", "\u30E4", "\u30E5", "\u30E6", "\u30E7", "\u30E8", "\u30E9", "\u30EA", "\u30EB", "\u30EC", "\u30ED", "\u30EE", "\u30EF", "\u30F0", "\u30F1", "\u30F2", "\u30F3", "\u30F4", "\u30F5", "\u30F6", "\u30F7", "\u30F8", "\u30F9", "\u30FA", "\u30FF", "\u3105", "\u3106", "\u3107", "\u3108", "\u3109", "\u310A", "\u310B", "\u310C", "\u310D", "\u310E", "\u310F", "\u3110", "\u3111", "\u3112", "\u3113", "\u3114", "\u3115", "\u3116", "\u3117", "\u3118", "\u3119", "\u311A", "\u311B", "\u311C", "\u311D", "\u311E", "\u311F", "\u3120", "\u3121", "\u3122", "\u3123", "\u3124", "\u3125", "\u3126", "\u3127", "\u3128", "\u3129", "\u312A", "\u312B", "\u312C", "\u312D", "\u3131", "\u3132", "\u3133", "\u3134", "\u3135", "\u3136", "\u3137", "\u3138", "\u3139", "\u313A", "\u313B", "\u313C", "\u313D", "\u313E", "\u313F", "\u3140", "\u3141", "\u3142", "\u3143", "\u3144", "\u3145", "\u3146", "\u3147", "\u3148", "\u3149", "\u314A", "\u314B", "\u314C", "\u314D", "\u314E", "\u314F", "\u3150", "\u3151", "\u3152", "\u3153", "\u3154", "\u3155", "\u3156", "\u3157", "\u3158", "\u3159", "\u315A", "\u315B", "\u315C", "\u315D", "\u315E", "\u315F", "\u3160", "\u3161", "\u3162", "\u3163", "\u3164", "\u3165", "\u3166", "\u3167", "\u3168", "\u3169", "\u316A", "\u316B", "\u316C", "\u316D", "\u316E", "\u316F", "\u3170", "\u3171", "\u3172", "\u3173", "\u3174", "\u3175", "\u3176", "\u3177", "\u3178", "\u3179", "\u317A", "\u317B", "\u317C", "\u317D", "\u317E", "\u317F", "\u3180", "\u3181", "\u3182", "\u3183", "\u3184", "\u3185", "\u3186", "\u3187", "\u3188", "\u3189", "\u318A", "\u318B", "\u318C", "\u318D", "\u318E", "\u31A0", "\u31A1", "\u31A2", "\u31A3", "\u31A4", "\u31A5", "\u31A6", "\u31A7", "\u31A8", "\u31A9", "\u31AA", "\u31AB", "\u31AC", "\u31AD", "\u31AE", "\u31AF", "\u31B0", "\u31B1", "\u31B2", "\u31B3", "\u31B4", "\u31B5", "\u31B6", "\u31B7", "\u31F0", "\u31F1", "\u31F2", "\u31F3", "\u31F4", "\u31F5", "\u31F6", "\u31F7", "\u31F8", "\u31F9", "\u31FA", "\u31FB", "\u31FC", "\u31FD", "\u31FE", "\u31FF", "\u3400", "\u4DB5", "\u4E00", "\u9FC3", "\uA000", "\uA001", "\uA002", "\uA003", "\uA004", "\uA005", "\uA006", "\uA007", "\uA008", "\uA009", "\uA00A", "\uA00B", "\uA00C", "\uA00D", "\uA00E", "\uA00F", "\uA010", "\uA011", "\uA012", "\uA013", "\uA014", "\uA016", "\uA017", "\uA018", "\uA019", "\uA01A", "\uA01B", "\uA01C", "\uA01D", "\uA01E", "\uA01F", "\uA020", "\uA021", "\uA022", "\uA023", "\uA024", "\uA025", "\uA026", "\uA027", "\uA028", "\uA029", "\uA02A", "\uA02B", "\uA02C", "\uA02D", "\uA02E", "\uA02F", "\uA030", "\uA031", "\uA032", "\uA033", "\uA034", "\uA035", "\uA036", "\uA037", "\uA038", "\uA039", "\uA03A", "\uA03B", "\uA03C", "\uA03D", "\uA03E", "\uA03F", "\uA040", "\uA041", "\uA042", "\uA043", "\uA044", "\uA045", "\uA046", "\uA047", "\uA048", "\uA049", "\uA04A", "\uA04B", "\uA04C", "\uA04D", "\uA04E", "\uA04F", "\uA050", "\uA051", "\uA052", "\uA053", "\uA054", "\uA055", "\uA056", "\uA057", "\uA058", "\uA059", "\uA05A", "\uA05B", "\uA05C", "\uA05D", "\uA05E", "\uA05F", "\uA060", "\uA061", "\uA062", "\uA063", "\uA064", "\uA065", "\uA066", "\uA067", "\uA068", "\uA069", "\uA06A", "\uA06B", "\uA06C", "\uA06D", "\uA06E", "\uA06F", "\uA070", "\uA071", "\uA072", "\uA073", "\uA074", "\uA075", "\uA076", "\uA077", "\uA078", "\uA079", "\uA07A", "\uA07B", "\uA07C", "\uA07D", "\uA07E", "\uA07F", "\uA080", "\uA081", "\uA082", "\uA083", "\uA084", "\uA085", "\uA086", "\uA087", "\uA088", "\uA089", "\uA08A", "\uA08B", "\uA08C", "\uA08D", "\uA08E", "\uA08F", "\uA090", "\uA091", "\uA092", "\uA093", "\uA094", "\uA095", "\uA096", "\uA097", "\uA098", "\uA099", "\uA09A", "\uA09B", "\uA09C", "\uA09D", "\uA09E", "\uA09F", "\uA0A0", "\uA0A1", "\uA0A2", "\uA0A3", "\uA0A4", "\uA0A5", "\uA0A6", "\uA0A7", "\uA0A8", "\uA0A9", "\uA0AA", "\uA0AB", "\uA0AC", "\uA0AD", "\uA0AE", "\uA0AF", "\uA0B0", "\uA0B1", "\uA0B2", "\uA0B3", "\uA0B4", "\uA0B5", "\uA0B6", "\uA0B7", "\uA0B8", "\uA0B9", "\uA0BA", "\uA0BB", "\uA0BC", "\uA0BD", "\uA0BE", "\uA0BF", "\uA0C0", "\uA0C1", "\uA0C2", "\uA0C3", "\uA0C4", "\uA0C5", "\uA0C6", "\uA0C7", "\uA0C8", "\uA0C9", "\uA0CA", "\uA0CB", "\uA0CC", "\uA0CD", "\uA0CE", "\uA0CF", "\uA0D0", "\uA0D1", "\uA0D2", "\uA0D3", "\uA0D4", "\uA0D5", "\uA0D6", "\uA0D7", "\uA0D8", "\uA0D9", "\uA0DA", "\uA0DB", "\uA0DC", "\uA0DD", "\uA0DE", "\uA0DF", "\uA0E0", "\uA0E1", "\uA0E2", "\uA0E3", "\uA0E4", "\uA0E5", "\uA0E6", "\uA0E7", "\uA0E8", "\uA0E9", "\uA0EA", "\uA0EB", "\uA0EC", "\uA0ED", "\uA0EE", "\uA0EF", "\uA0F0", "\uA0F1", "\uA0F2", "\uA0F3", "\uA0F4", "\uA0F5", "\uA0F6", "\uA0F7", "\uA0F8", "\uA0F9", "\uA0FA", "\uA0FB", "\uA0FC", "\uA0FD", "\uA0FE", "\uA0FF", "\uA100", "\uA101", "\uA102", "\uA103", "\uA104", "\uA105", "\uA106", "\uA107", "\uA108", "\uA109", "\uA10A", "\uA10B", "\uA10C", "\uA10D", "\uA10E", "\uA10F", "\uA110", "\uA111", "\uA112", "\uA113", "\uA114", "\uA115", "\uA116", "\uA117", "\uA118", "\uA119", "\uA11A", "\uA11B", "\uA11C", "\uA11D", "\uA11E", "\uA11F", "\uA120", "\uA121", "\uA122", "\uA123", "\uA124", "\uA125", "\uA126", "\uA127", "\uA128", "\uA129", "\uA12A", "\uA12B", "\uA12C", "\uA12D", "\uA12E", "\uA12F", "\uA130", "\uA131", "\uA132", "\uA133", "\uA134", "\uA135", "\uA136", "\uA137", "\uA138", "\uA139", "\uA13A", "\uA13B", "\uA13C", "\uA13D", "\uA13E", "\uA13F", "\uA140", "\uA141", "\uA142", "\uA143", "\uA144", "\uA145", "\uA146", "\uA147", "\uA148", "\uA149", "\uA14A", "\uA14B", "\uA14C", "\uA14D", "\uA14E", "\uA14F", "\uA150", "\uA151", "\uA152", "\uA153", "\uA154", "\uA155", "\uA156", "\uA157", "\uA158", "\uA159", "\uA15A", "\uA15B", "\uA15C", "\uA15D", "\uA15E", "\uA15F", "\uA160", "\uA161", "\uA162", "\uA163", "\uA164", "\uA165", "\uA166", "\uA167", "\uA168", "\uA169", "\uA16A", "\uA16B", "\uA16C", "\uA16D", "\uA16E", "\uA16F", "\uA170", "\uA171", "\uA172", "\uA173", "\uA174", "\uA175", "\uA176", "\uA177", "\uA178", "\uA179", "\uA17A", "\uA17B", "\uA17C", "\uA17D", "\uA17E", "\uA17F", "\uA180", "\uA181", "\uA182", "\uA183", "\uA184", "\uA185", "\uA186", "\uA187", "\uA188", "\uA189", "\uA18A", "\uA18B", "\uA18C", "\uA18D", "\uA18E", "\uA18F", "\uA190", "\uA191", "\uA192", "\uA193", "\uA194", "\uA195", "\uA196", "\uA197", "\uA198", "\uA199", "\uA19A", "\uA19B", "\uA19C", "\uA19D", "\uA19E", "\uA19F", "\uA1A0", "\uA1A1", "\uA1A2", "\uA1A3", "\uA1A4", "\uA1A5", "\uA1A6", "\uA1A7", "\uA1A8", "\uA1A9", "\uA1AA", "\uA1AB", "\uA1AC", "\uA1AD", "\uA1AE", "\uA1AF"], false, false),
+      peg$c260 = peg$otherExpectation("Unicode letter number"),
+      peg$c261 = /^[\u16EE\u16EF\u16F0\u2160\u2161\u2162\u2163\u2164\u2165\u2166\u2167\u2168\u2169\u216A\u216B\u216C\u216D\u216E\u216F\u2170\u2171\u2172\u2173\u2174\u2175\u2176\u2177\u2178\u2179\u217A\u217B\u217C\u217D\u217E\u217F\u2180\u2181\u2182\u2185\u2186\u2187\u2188\u3007\u3021\u3022\u3023\u3024\u3025\u3026\u3027\u3028\u3029\u3038\u3039\u303A]/,
+      peg$c262 = peg$classExpectation(["\u16EE", "\u16EF", "\u16F0", "\u2160", "\u2161", "\u2162", "\u2163", "\u2164", "\u2165", "\u2166", "\u2167", "\u2168", "\u2169", "\u216A", "\u216B", "\u216C", "\u216D", "\u216E", "\u216F", "\u2170", "\u2171", "\u2172", "\u2173", "\u2174", "\u2175", "\u2176", "\u2177", "\u2178", "\u2179", "\u217A", "\u217B", "\u217C", "\u217D", "\u217E", "\u217F", "\u2180", "\u2181", "\u2182", "\u2185", "\u2186", "\u2187", "\u2188", "\u3007", "\u3021", "\u3022", "\u3023", "\u3024", "\u3025", "\u3026", "\u3027", "\u3028", "\u3029", "\u3038", "\u3039", "\u303A"], false, false),
+      peg$c263 = peg$otherExpectation("Unicode separator, space"),
+      peg$c264 = /^[ \xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000]/,
+      peg$c265 = peg$classExpectation([" ", "\xA0", "\u1680", "\u180E", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005", "\u2006", "\u2007", "\u2008", "\u2009", "\u200A", "\u202F", "\u205F", "\u3000"], false, false),
+      peg$c266 = function(c) {
               return c;
           },
-      peg$c264 = function(seq) {
+      peg$c267 = function(seq) {
               return seq;
           },
-      peg$c265 = "\n",
-      peg$c266 = peg$literalExpectation("\n", false),
-      peg$c267 = "\r",
-      peg$c268 = peg$literalExpectation("\r", false),
-      peg$c269 = "\u2028",
-      peg$c270 = peg$literalExpectation("\u2028", false),
-      peg$c271 = "\u2029",
-      peg$c272 = peg$literalExpectation("\u2029", false),
-      peg$c273 = "\r\n",
-      peg$c274 = peg$literalExpectation("\r\n", false),
-      peg$c275 = function() {
+      peg$c268 = "\n",
+      peg$c269 = peg$literalExpectation("\n", false),
+      peg$c270 = "\r",
+      peg$c271 = peg$literalExpectation("\r", false),
+      peg$c272 = "\u2028",
+      peg$c273 = peg$literalExpectation("\u2028", false),
+      peg$c274 = "\u2029",
+      peg$c275 = peg$literalExpectation("\u2029", false),
+      peg$c276 = "\r\n",
+      peg$c277 = peg$literalExpectation("\r\n", false),
+      peg$c278 = function() {
               return '0';
           },
-      peg$c276 = /^['"\\bfnrtv]/,
-      peg$c277 = peg$classExpectation(["'", "\"", "\\", "b", "f", "n", "r", "t", "v"], false, false),
-      peg$c278 = "x",
-      peg$c279 = peg$literalExpectation("x", false),
-      peg$c280 = peg$anyExpectation(),
-      peg$c281 = peg$otherExpectation("whitespace"),
-      peg$c282 = peg$otherExpectation("empty"),
-      peg$c283 = "",
-      peg$c284 = /^[\t\x0B\f \xA0\uFEFF]/,
-      peg$c285 = peg$classExpectation(["\t", "\x0B", "\f", " ", "\xA0", "\uFEFF"], false, false),
+      peg$c279 = /^['"\\bfnrtv]/,
+      peg$c280 = peg$classExpectation(["'", "\"", "\\", "b", "f", "n", "r", "t", "v"], false, false),
+      peg$c281 = "x",
+      peg$c282 = peg$literalExpectation("x", false),
+      peg$c283 = peg$anyExpectation(),
+      peg$c284 = peg$otherExpectation("whitespace"),
+      peg$c285 = peg$otherExpectation("empty"),
+      peg$c286 = "",
+      peg$c287 = /^[\t\x0B\f \xA0\uFEFF]/,
+      peg$c288 = peg$classExpectation(["\t", "\x0B", "\f", " ", "\xA0", "\uFEFF"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1154,7 +1171,10 @@ function peg$parse(input, options) {
 
     s0 = peg$parseTypeUnion();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseRestrictedTypeExpression();
+      s0 = peg$parseTypeTuple();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseRestrictedTypeExpression();
+      }
     }
 
     return s0;
@@ -3553,6 +3573,226 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseTypeTuple() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c63;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c64); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseTupleMember();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseTupleTail();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 93) {
+                s6 = peg$c65;
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c66); }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c97(s3, s4);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseTupleTail() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
+    if (s3 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 44) {
+        s4 = peg$c37;
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+      }
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parse_();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseTupleMember();
+          if (s6 !== peg$FAILED) {
+            s3 = [s3, s4, s5, s6];
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parse_();
+      if (s3 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s4 = peg$c37;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse_();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseTupleMember();
+            if (s6 !== peg$FAILED) {
+              s3 = [s3, s4, s5, s6];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c98(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseTupleMember() {
+    var s0;
+
+    s0 = peg$parseNamedTupleMember();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseUnnamedTupleMember();
+    }
+
+    return s0;
+  }
+
+  function peg$parseUnnamedTupleMember() {
+    var s0;
+
+    s0 = peg$parseTypeExpression();
+
+    return s0;
+  }
+
+  function peg$parseNamedTupleMember() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseIdentifier();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s4 = peg$c46;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseTypeExpression();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parse_();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c99(s2, s6);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseNamespaceExpression() {
     var s0;
 
@@ -3582,7 +3822,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifierName();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97(s2);
+        s1 = peg$c100(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3646,27 +3886,27 @@ function peg$parse(input, options) {
       s0 = peg$parseNumericLiteral();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 36) {
-          s0 = peg$c98;
+          s0 = peg$c101;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+          if (peg$silentFails === 0) { peg$fail(peg$c102); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 95) {
-            s0 = peg$c100;
+            s0 = peg$c103;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c104); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 64) {
-              s0 = peg$c102;
+              s0 = peg$c105;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c106); }
             }
             if (s0 === peg$FAILED) {
               s0 = peg$parseUnicodeEscapeSequenceLiteral();
@@ -3685,11 +3925,11 @@ function peg$parse(input, options) {
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c104;
+        s0 = peg$c107;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$parseUnicodeMc();
@@ -3699,19 +3939,19 @@ function peg$parse(input, options) {
             s0 = peg$parseUnicodePc();
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 8204) {
-                s0 = peg$c106;
+                s0 = peg$c109;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c107); }
+                if (peg$silentFails === 0) { peg$fail(peg$c110); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 8205) {
-                  s0 = peg$c108;
+                  s0 = peg$c111;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c109); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c112); }
                 }
               }
             }
@@ -3755,7 +3995,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c110(s3);
+              s1 = peg$c113(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3805,7 +4045,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c111(s3);
+                s1 = peg$c114(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3857,118 +4097,118 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c112) {
-      s2 = peg$c112;
+    if (input.substr(peg$currPos, 5) === peg$c115) {
+      s2 = peg$c115;
       peg$currPos += 5;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c113); }
+      if (peg$silentFails === 0) { peg$fail(peg$c116); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c114) {
-        s2 = peg$c114;
+      if (input.substr(peg$currPos, 4) === peg$c117) {
+        s2 = peg$c117;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c116) {
-          s2 = peg$c116;
+        if (input.substr(peg$currPos, 5) === peg$c119) {
+          s2 = peg$c119;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 8) === peg$c118) {
-            s2 = peg$c118;
+          if (input.substr(peg$currPos, 8) === peg$c121) {
+            s2 = peg$c121;
             peg$currPos += 8;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c119); }
+            if (peg$silentFails === 0) { peg$fail(peg$c122); }
           }
           if (s2 === peg$FAILED) {
-            if (input.substr(peg$currPos, 8) === peg$c120) {
-              s2 = peg$c120;
+            if (input.substr(peg$currPos, 8) === peg$c123) {
+              s2 = peg$c123;
               peg$currPos += 8;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c121); }
+              if (peg$silentFails === 0) { peg$fail(peg$c124); }
             }
             if (s2 === peg$FAILED) {
-              if (input.substr(peg$currPos, 7) === peg$c122) {
-                s2 = peg$c122;
+              if (input.substr(peg$currPos, 7) === peg$c125) {
+                s2 = peg$c125;
                 peg$currPos += 7;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                if (peg$silentFails === 0) { peg$fail(peg$c126); }
               }
               if (s2 === peg$FAILED) {
-                if (input.substr(peg$currPos, 6) === peg$c124) {
-                  s2 = peg$c124;
+                if (input.substr(peg$currPos, 6) === peg$c127) {
+                  s2 = peg$c127;
                   peg$currPos += 6;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c125); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c128); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c126) {
-                    s2 = peg$c126;
+                  if (input.substr(peg$currPos, 2) === peg$c129) {
+                    s2 = peg$c129;
                     peg$currPos += 2;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
                   }
                   if (s2 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c128) {
-                      s2 = peg$c128;
+                    if (input.substr(peg$currPos, 4) === peg$c131) {
+                      s2 = peg$c131;
                       peg$currPos += 4;
                     } else {
                       s2 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c132); }
                     }
                     if (s2 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 7) === peg$c130) {
-                        s2 = peg$c130;
+                      if (input.substr(peg$currPos, 7) === peg$c133) {
+                        s2 = peg$c133;
                         peg$currPos += 7;
                       } else {
                         s2 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c134); }
                       }
                       if (s2 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3) === peg$c132) {
-                          s2 = peg$c132;
+                        if (input.substr(peg$currPos, 3) === peg$c135) {
+                          s2 = peg$c135;
                           peg$currPos += 3;
                         } else {
                           s2 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c136); }
                         }
                         if (s2 === peg$FAILED) {
                           s2 = peg$parseFunctionLiteralLc();
                           if (s2 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2) === peg$c134) {
-                              s2 = peg$c134;
+                            if (input.substr(peg$currPos, 2) === peg$c137) {
+                              s2 = peg$c137;
                               peg$currPos += 2;
                             } else {
                               s2 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c135); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c138); }
                             }
                             if (s2 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 2) === peg$c136) {
-                                s2 = peg$c136;
+                              if (input.substr(peg$currPos, 2) === peg$c139) {
+                                s2 = peg$c139;
                                 peg$currPos += 2;
                               } else {
                                 s2 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c137); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c140); }
                               }
                               if (s2 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 10) === peg$c138) {
-                                  s2 = peg$c138;
+                                if (input.substr(peg$currPos, 10) === peg$c141) {
+                                  s2 = peg$c141;
                                   peg$currPos += 10;
                                 } else {
                                   s2 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c142); }
                                 }
                                 if (s2 === peg$FAILED) {
                                   if (input.substr(peg$currPos, 3) === peg$c52) {
@@ -3979,20 +4219,20 @@ function peg$parse(input, options) {
                                     if (peg$silentFails === 0) { peg$fail(peg$c53); }
                                   }
                                   if (s2 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 6) === peg$c140) {
-                                      s2 = peg$c140;
+                                    if (input.substr(peg$currPos, 6) === peg$c143) {
+                                      s2 = peg$c143;
                                       peg$currPos += 6;
                                     } else {
                                       s2 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c144); }
                                     }
                                     if (s2 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 6) === peg$c142) {
-                                        s2 = peg$c142;
+                                      if (input.substr(peg$currPos, 6) === peg$c145) {
+                                        s2 = peg$c145;
                                         peg$currPos += 6;
                                       } else {
                                         s2 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c146); }
                                       }
                                       if (s2 === peg$FAILED) {
                                         if (input.substr(peg$currPos, 4) === peg$c55) {
@@ -4003,60 +4243,60 @@ function peg$parse(input, options) {
                                           if (peg$silentFails === 0) { peg$fail(peg$c56); }
                                         }
                                         if (s2 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c144) {
-                                            s2 = peg$c144;
+                                          if (input.substr(peg$currPos, 5) === peg$c147) {
+                                            s2 = peg$c147;
                                             peg$currPos += 5;
                                           } else {
                                             s2 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c145); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c148); }
                                           }
                                           if (s2 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 3) === peg$c146) {
-                                              s2 = peg$c146;
+                                            if (input.substr(peg$currPos, 3) === peg$c149) {
+                                              s2 = peg$c149;
                                               peg$currPos += 3;
                                             } else {
                                               s2 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c147); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c150); }
                                             }
                                             if (s2 === peg$FAILED) {
-                                              if (input.substr(peg$currPos, 6) === peg$c148) {
-                                                s2 = peg$c148;
+                                              if (input.substr(peg$currPos, 6) === peg$c151) {
+                                                s2 = peg$c151;
                                                 peg$currPos += 6;
                                               } else {
                                                 s2 = peg$FAILED;
-                                                if (peg$silentFails === 0) { peg$fail(peg$c149); }
+                                                if (peg$silentFails === 0) { peg$fail(peg$c152); }
                                               }
                                               if (s2 === peg$FAILED) {
-                                                if (input.substr(peg$currPos, 3) === peg$c150) {
-                                                  s2 = peg$c150;
+                                                if (input.substr(peg$currPos, 3) === peg$c153) {
+                                                  s2 = peg$c153;
                                                   peg$currPos += 3;
                                                 } else {
                                                   s2 = peg$FAILED;
-                                                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                                                  if (peg$silentFails === 0) { peg$fail(peg$c154); }
                                                 }
                                                 if (s2 === peg$FAILED) {
-                                                  if (input.substr(peg$currPos, 4) === peg$c152) {
-                                                    s2 = peg$c152;
+                                                  if (input.substr(peg$currPos, 4) === peg$c155) {
+                                                    s2 = peg$c155;
                                                     peg$currPos += 4;
                                                   } else {
                                                     s2 = peg$FAILED;
-                                                    if (peg$silentFails === 0) { peg$fail(peg$c153); }
+                                                    if (peg$silentFails === 0) { peg$fail(peg$c156); }
                                                   }
                                                   if (s2 === peg$FAILED) {
-                                                    if (input.substr(peg$currPos, 5) === peg$c154) {
-                                                      s2 = peg$c154;
+                                                    if (input.substr(peg$currPos, 5) === peg$c157) {
+                                                      s2 = peg$c157;
                                                       peg$currPos += 5;
                                                     } else {
                                                       s2 = peg$FAILED;
-                                                      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+                                                      if (peg$silentFails === 0) { peg$fail(peg$c158); }
                                                     }
                                                     if (s2 === peg$FAILED) {
-                                                      if (input.substr(peg$currPos, 4) === peg$c156) {
-                                                        s2 = peg$c156;
+                                                      if (input.substr(peg$currPos, 4) === peg$c159) {
+                                                        s2 = peg$c159;
                                                         peg$currPos += 4;
                                                       } else {
                                                         s2 = peg$FAILED;
-                                                        if (peg$silentFails === 0) { peg$fail(peg$c157); }
+                                                        if (peg$silentFails === 0) { peg$fail(peg$c160); }
                                                       }
                                                     }
                                                   }
@@ -4101,7 +4341,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1);
+        s1 = peg$c161(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4120,132 +4360,132 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c159) {
-      s2 = peg$c159;
+    if (input.substr(peg$currPos, 5) === peg$c162) {
+      s2 = peg$c162;
       peg$currPos += 5;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c160); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c161) {
-        s2 = peg$c161;
+      if (input.substr(peg$currPos, 5) === peg$c164) {
+        s2 = peg$c164;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c162); }
+        if (peg$silentFails === 0) { peg$fail(peg$c165); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c163) {
-          s2 = peg$c163;
+        if (input.substr(peg$currPos, 4) === peg$c166) {
+          s2 = peg$c166;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c164); }
+          if (peg$silentFails === 0) { peg$fail(peg$c167); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c165) {
-            s2 = peg$c165;
+          if (input.substr(peg$currPos, 6) === peg$c168) {
+            s2 = peg$c168;
             peg$currPos += 6;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c166); }
+            if (peg$silentFails === 0) { peg$fail(peg$c169); }
           }
           if (s2 === peg$FAILED) {
-            if (input.substr(peg$currPos, 7) === peg$c167) {
-              s2 = peg$c167;
+            if (input.substr(peg$currPos, 7) === peg$c170) {
+              s2 = peg$c170;
               peg$currPos += 7;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c168); }
+              if (peg$silentFails === 0) { peg$fail(peg$c171); }
             }
             if (s2 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c169) {
-                s2 = peg$c169;
+              if (input.substr(peg$currPos, 6) === peg$c172) {
+                s2 = peg$c172;
                 peg$currPos += 6;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c170); }
+                if (peg$silentFails === 0) { peg$fail(peg$c173); }
               }
               if (s2 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c171) {
-                  s2 = peg$c171;
+                if (input.substr(peg$currPos, 5) === peg$c174) {
+                  s2 = peg$c174;
                   peg$currPos += 5;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c172); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c175); }
                 }
                 if (s2 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 10) === peg$c173) {
-                    s2 = peg$c173;
+                  if (input.substr(peg$currPos, 10) === peg$c176) {
+                    s2 = peg$c176;
                     peg$currPos += 10;
                   } else {
                     s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c174); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c177); }
                   }
                   if (s2 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 9) === peg$c175) {
-                      s2 = peg$c175;
+                    if (input.substr(peg$currPos, 9) === peg$c178) {
+                      s2 = peg$c178;
                       peg$currPos += 9;
                     } else {
                       s2 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c176); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c179); }
                     }
                     if (s2 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c177) {
-                        s2 = peg$c177;
+                      if (input.substr(peg$currPos, 3) === peg$c180) {
+                        s2 = peg$c180;
                         peg$currPos += 3;
                       } else {
                         s2 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c178); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c181); }
                       }
                       if (s2 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c179) {
-                          s2 = peg$c179;
+                        if (input.substr(peg$currPos, 7) === peg$c182) {
+                          s2 = peg$c182;
                           peg$currPos += 7;
                         } else {
                           s2 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c183); }
                         }
                         if (s2 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c181) {
-                            s2 = peg$c181;
+                          if (input.substr(peg$currPos, 7) === peg$c184) {
+                            s2 = peg$c184;
                             peg$currPos += 7;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c182); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c185); }
                           }
                           if (s2 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 9) === peg$c183) {
-                              s2 = peg$c183;
+                            if (input.substr(peg$currPos, 9) === peg$c186) {
+                              s2 = peg$c186;
                               peg$currPos += 9;
                             } else {
                               s2 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c184); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c187); }
                             }
                             if (s2 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 6) === peg$c185) {
-                                s2 = peg$c185;
+                              if (input.substr(peg$currPos, 6) === peg$c188) {
+                                s2 = peg$c188;
                                 peg$currPos += 6;
                               } else {
                                 s2 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c186); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c189); }
                               }
                               if (s2 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c187) {
-                                  s2 = peg$c187;
+                                if (input.substr(peg$currPos, 6) === peg$c190) {
+                                  s2 = peg$c190;
                                   peg$currPos += 6;
                                 } else {
                                   s2 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c188); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c191); }
                                 }
                                 if (s2 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c189) {
-                                    s2 = peg$c189;
+                                  if (input.substr(peg$currPos, 5) === peg$c192) {
+                                    s2 = peg$c192;
                                     peg$currPos += 5;
                                   } else {
                                     s2 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c190); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c193); }
                                   }
                                 }
                               }
@@ -4280,7 +4520,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c191(s1);
+        s1 = peg$c194(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4310,11 +4550,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c192;
+      s1 = peg$c195;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -4325,15 +4565,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c192;
+          s3 = peg$c195;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c194(s2);
+          s1 = peg$c197(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4356,11 +4596,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -4371,15 +4611,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c195;
+          s3 = peg$c198;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c194(s2);
+          s1 = peg$c197(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4433,7 +4673,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c197(s1, s3, s4);
+            s1 = peg$c200(s1, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4469,7 +4709,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c198(s2, s3);
+            s1 = peg$c201(s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4493,7 +4733,7 @@ function peg$parse(input, options) {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c199(s1, s2);
+            s1 = peg$c202(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4513,11 +4753,11 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c200;
+      s0 = peg$c203;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
@@ -4603,12 +4843,12 @@ function peg$parse(input, options) {
   function peg$parseExponentIndicator() {
     var s0;
 
-    if (peg$c202.test(input.charAt(peg$currPos))) {
+    if (peg$c205.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c203); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
 
     return s0;
@@ -4619,12 +4859,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (peg$c204.test(input.charAt(peg$currPos))) {
+    if (peg$c207.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s2 === peg$FAILED) {
       s2 = null;
@@ -4656,19 +4896,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 48) {
-      s1 = peg$c200;
+      s1 = peg$c203;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c201); }
+      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c206.test(input.charAt(peg$currPos))) {
+      if (peg$c209.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c207); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
@@ -4689,7 +4929,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c208(s3);
+          s1 = peg$c211(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4710,12 +4950,12 @@ function peg$parse(input, options) {
   function peg$parseNullLiteral() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c209) {
-      s0 = peg$c209;
+    if (input.substr(peg$currPos, 4) === peg$c212) {
+      s0 = peg$c212;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+      if (peg$silentFails === 0) { peg$fail(peg$c213); }
     }
 
     return s0;
@@ -4724,12 +4964,12 @@ function peg$parse(input, options) {
   function peg$parseUndefinedLiteral() {
     var s0;
 
-    if (input.substr(peg$currPos, 9) === peg$c211) {
-      s0 = peg$c211;
+    if (input.substr(peg$currPos, 9) === peg$c214) {
+      s0 = peg$c214;
       peg$currPos += 9;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
 
     return s0;
@@ -4748,7 +4988,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c213();
+      s1 = peg$c216();
     }
     s0 = s1;
 
@@ -4758,20 +4998,20 @@ function peg$parse(input, options) {
   function peg$parseBooleanLiteral() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c214) {
-      s0 = peg$c214;
+    if (input.substr(peg$currPos, 4) === peg$c217) {
+      s0 = peg$c217;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c216) {
-        s0 = peg$c216;
+      if (input.substr(peg$currPos, 5) === peg$c219) {
+        s0 = peg$c219;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
     }
 
@@ -4792,12 +5032,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionLiteralUc() {
     var s0;
 
-    if (input.substr(peg$currPos, 8) === peg$c218) {
-      s0 = peg$c218;
+    if (input.substr(peg$currPos, 8) === peg$c221) {
+      s0 = peg$c221;
       peg$currPos += 8;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c219); }
+      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
 
     return s0;
@@ -4806,12 +5046,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionLiteralLc() {
     var s0;
 
-    if (input.substr(peg$currPos, 8) === peg$c220) {
-      s0 = peg$c220;
+    if (input.substr(peg$currPos, 8) === peg$c223) {
+      s0 = peg$c223;
       peg$currPos += 8;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c221); }
+      if (peg$silentFails === 0) { peg$fail(peg$c224); }
     }
 
     return s0;
@@ -4846,11 +5086,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s2 = peg$c222;
+      s2 = peg$c225;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parseUnicodeEscapeSequence();
@@ -4879,11 +5119,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c224;
+      s1 = peg$c227;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c228); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4921,7 +5161,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c226(s2);
+        s1 = peg$c229(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4938,12 +5178,12 @@ function peg$parse(input, options) {
   function peg$parseDecimalDigit() {
     var s0;
 
-    if (peg$c227.test(input.charAt(peg$currPos))) {
+    if (peg$c230.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c228); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
 
     return s0;
@@ -4952,12 +5192,12 @@ function peg$parse(input, options) {
   function peg$parseNonZeroDigit() {
     var s0;
 
-    if (peg$c229.test(input.charAt(peg$currPos))) {
+    if (peg$c232.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
 
     return s0;
@@ -4966,21 +5206,6 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c231.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseUnicodeMc() {
-    var s0, s1;
-
-    peg$silentFails++;
     if (peg$c234.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
@@ -4988,16 +5213,11 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
-    }
 
     return s0;
   }
 
-  function peg$parseUnicodeNd() {
+  function peg$parseUnicodeMc() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5017,7 +5237,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodePc() {
+  function peg$parseUnicodeNd() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5037,7 +5257,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLu() {
+  function peg$parseUnicodePc() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5057,7 +5277,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLl() {
+  function peg$parseUnicodeLu() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5077,7 +5297,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLt() {
+  function peg$parseUnicodeLl() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5097,7 +5317,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLm() {
+  function peg$parseUnicodeLt() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5117,7 +5337,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLo() {
+  function peg$parseUnicodeLm() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5137,7 +5357,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeLn() {
+  function peg$parseUnicodeLo() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5157,7 +5377,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnicodeZs() {
+  function peg$parseUnicodeLn() {
     var s0, s1;
 
     peg$silentFails++;
@@ -5177,6 +5397,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseUnicodeZs() {
+    var s0, s1;
+
+    peg$silentFails++;
+    if (peg$c264.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c265); }
+    }
+    peg$silentFails--;
+    if (s0 === peg$FAILED) {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+    }
+
+    return s0;
+  }
+
   function peg$parseDoubleStringCharacter() {
     var s0, s1, s2;
 
@@ -5184,19 +5424,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c192;
+      s2 = peg$c195;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c222;
+        s2 = peg$c225;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseLineTerminator();
@@ -5213,7 +5453,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c263(s2);
+        s1 = peg$c266(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5226,17 +5466,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c222;
+        s1 = peg$c225;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c264(s2);
+          s1 = peg$c267(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5261,19 +5501,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c195;
+      s2 = peg$c198;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c222;
+        s2 = peg$c225;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseLineTerminator();
@@ -5290,7 +5530,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c263(s2);
+        s1 = peg$c266(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5303,17 +5543,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c222;
+        s1 = peg$c225;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c264(s2);
+          s1 = peg$c267(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5335,30 +5575,30 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c265;
+      s0 = peg$c268;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 13) {
-        s1 = peg$c267;
+        s1 = peg$c270;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 10) {
-          s3 = peg$c265;
+          s3 = peg$c268;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c269); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5380,27 +5620,27 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 8232) {
-          s0 = peg$c269;
+          s0 = peg$c272;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8233) {
-            s0 = peg$c271;
+            s0 = peg$c274;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c275); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c273) {
-              s0 = peg$c273;
+            if (input.substr(peg$currPos, 2) === peg$c276) {
+              s0 = peg$c276;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c274); }
+              if (peg$silentFails === 0) { peg$fail(peg$c277); }
             }
           }
         }
@@ -5414,35 +5654,35 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c265;
+      s0 = peg$c268;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 13) {
-        s0 = peg$c267;
+        s0 = peg$c270;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 8232) {
-          s0 = peg$c269;
+          s0 = peg$c272;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8233) {
-            s0 = peg$c271;
+            s0 = peg$c274;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c275); }
           }
         }
       }
@@ -5458,11 +5698,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s1 = peg$c200;
+        s1 = peg$c203;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c201); }
+        if (peg$silentFails === 0) { peg$fail(peg$c204); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -5477,7 +5717,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c275();
+          s1 = peg$c278();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5512,12 +5752,12 @@ function peg$parse(input, options) {
   function peg$parseSingleEscapeCharacter() {
     var s0;
 
-    if (peg$c276.test(input.charAt(peg$currPos))) {
+    if (peg$c279.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
 
     return s0;
@@ -5544,7 +5784,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c263(s2);
+        s1 = peg$c266(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5566,19 +5806,19 @@ function peg$parse(input, options) {
       s0 = peg$parseDecimalDigit();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 120) {
-          s0 = peg$c278;
+          s0 = peg$c281;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c282); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 117) {
-            s0 = peg$c224;
+            s0 = peg$c227;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c225); }
+            if (peg$silentFails === 0) { peg$fail(peg$c228); }
           }
         }
       }
@@ -5595,7 +5835,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c283); }
     }
 
     return s0;
@@ -5606,11 +5846,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c278;
+      s1 = peg$c281;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -5636,7 +5876,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c226(s2);
+        s1 = peg$c229(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5655,17 +5895,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c222;
+      s1 = peg$c225;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c264(s2);
+        s1 = peg$c267(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5692,7 +5932,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
 
     return s0;
@@ -5702,11 +5942,11 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    s0 = peg$c283;
+    s0 = peg$c286;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
 
     return s0;
@@ -5715,12 +5955,12 @@ function peg$parse(input, options) {
   function peg$parseWhitespace() {
     var s0;
 
-    if (peg$c284.test(input.charAt(peg$currPos))) {
+    if (peg$c287.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$parseUnicodeZs();
@@ -5748,6 +5988,10 @@ function peg$parse(input, options) {
           }
 
           return obj;
+      }
+
+      function prop3(arr) {
+          return arr[3];
       }
 
 

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -29,6 +29,10 @@
 
         return obj;
     }
+
+    function prop3(arr) {
+        return arr[3];
+    }
 }
 
 TypeExpression
@@ -74,6 +78,7 @@ TypeExpression
 
 BasicTypeExpression
     = TypeUnion
+    / TypeTuple
     / RestrictedTypeExpression
 
 RestrictedTypeExpression
@@ -618,6 +623,35 @@ PropertyChainItem
         }
 
         return sep + prop;
+    }
+
+TypeTuple
+    = "[" _ head:TupleMember tail:TupleTail _ "]" {
+        let elements = [head].concat(tail);
+        return {
+            type: Types.TypeTuple,
+            elements: elements
+        };
+    }
+
+TupleTail
+    = tail: (_ "," _ TupleMember)* {
+        return tail.map(prop3);
+    }
+
+TupleMember
+    = NamedTupleMember / UnnamedTupleMember
+
+UnnamedTupleMember
+    = str:TypeExpression
+
+NamedTupleMember
+    = _ key:Identifier _ ":" _ value:TypeExpression _ {
+        return {
+            type: Types.NamedTupleMember,
+            key: key,
+            value: value
+        }
     }
 
 NamespaceExpression

--- a/lib/types.js
+++ b/lib/types.js
@@ -15,6 +15,10 @@ module.exports = Object.freeze({
     TypeApplication: 'TypeApplication',
     // like `(number|string)`
     TypeUnion: 'TypeUnion',
+    // like `[number, number]` or `[key: string, value: number]`
+    TypeTuple: 'TypeTuple',
+    // like `key: string` in `[key: string, value: number]`
+    NamedTupleMember: 'NamedTupleMember',
     // undefined
     UndefinedLiteral: 'UndefinedLiteral',
     // `?`


### PR DESCRIPTION
Hi @hegemonic,

I would like to see tuple support, which is requested since 2015 and 2017 you mentioned you are open for a PR: https://github.com/jsdoc/jsdoc/issues/1073#issuecomment-312524697

So this is the first step. As soon as `catharsis` returns a proper AST, JSDoc can correctly implement the documentation for it.

The AST naming is inspired by TypeScript:

Input 1:

```js
catharsis = require("./catharsis")
const ret = catharsis.parse("[a: string, b: number]", {jsdoc: true});
console.log(JSON.stringify(ret, null, 2));
```

Output 1:

```js
{
  "type": "TypeTuple",
  "elements": [
    {
      "type": "NamedTupleMember",
      "key": "a",
      "value": {
        "type": "NameExpression",
        "name": "string"
      }
    },
    {
      "type": "NamedTupleMember",
      "key": "b",
      "value": {
        "type": "NameExpression",
        "name": "number"
      }
    }
  ]
}
```

Input 2:

```js
catharsis = require("./catharsis")
const ret = catharsis.parse("[action: string, id: 1|2|3]", {jsdoc: true});
console.log(JSON.stringify(ret, null, 2));
```

Output 2:

```js
{
  "type": "TypeTuple",
  "elements": [
    {
      "type": "NamedTupleMember",
      "key": "action",
      "value": {
        "type": "NameExpression",
        "name": "string"
      }
    },
    {
      "type": "NamedTupleMember",
      "key": "id",
      "value": {
        "type": "TypeUnion",
        "elements": [
          {
            "type": "NameExpression",
            "name": "1"
          },
          {
            "type": "NameExpression",
            "name": "2"
          },
          {
            "type": "NameExpression",
            "name": "3"
          }
        ]
      }
    }
  ]
}
```

